### PR TITLE
initial appveyor.yml CI config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+
+environment:
+  matrix:
+    #- PlatformToolset: v140
+    - PlatformToolset: v141
+
+platform:
+    - x86
+    - x64
+
+configuration:
+    - Release
+    - Debug
+
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild NppMarkdownPanel.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+# after_build:
+    # - cd "%APPVEYOR_BUILD_FOLDER%"
+    # - ps: >-
+        # Push-AppveyorArtifact "NppMarkdownPanel\bin\$env:CONFIGURATION\NppMarkdownPanel.dll" -FileName NppMarkdownPanel.dll
+
+        # if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141") {
+            # $ZipFileName = "NppMarkdownPanel_$($env:APPVEYOR_REPO_TAG_NAME).zip"
+            # 7z a $ZipFileName NppMarkdownPanel\bin\$env:CONFIGURATION\NppMarkdownPanel.dll
+        # }
+
+# artifacts:
+  # - path: NppMarkdownPanel_*.zip
+    # name: releases
+
+# deploy:
+    # provider: GitHub
+    # auth_token:
+        # secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    # artifact: releases
+    # draft: false
+    # prerelease: false
+    # force_update: true
+    # on:
+        # appveyor_repo_tag: true
+        # PlatformToolset: v141
+        # configuration: Release


### PR DESCRIPTION
see https://ci.appveyor.com/project/chcg/nppmarkdownpanel/builds/23405476

Could be extended to publish build artifacts and create github releases, see commented parts (not adapted yet)