### PR TITLE
Wrap code fences in `<pre>` tags regardless of language label

### DIFF
--- a/MarkdigWrapper/LanguageTypeAdapter.cs
+++ b/MarkdigWrapper/LanguageTypeAdapter.cs
@@ -34,7 +34,26 @@ namespace Markdig.SyntaxHighlighting {
 
             var byIdCanidate = Languages.FindById(id);
 
-            return byIdCanidate;
+            // if no matching id, use plain text "style"
+            return byIdCanidate ?? new PlainText();
+        }
+
+        internal class PlainText : ILanguage {
+            string ILanguage.Id => "text";
+            string ILanguage.CssClassName => "text";
+            string ILanguage.Name => "Text";
+            string ILanguage.FirstLinePattern => string.Empty;
+            bool ILanguage.HasAlias(string lang) => false;
+
+            IList<LanguageRule> ILanguage.Rules {
+                get {
+                    return new List<LanguageRule> {
+                    new LanguageRule(
+                        @"(?s).*?",
+                        new Dictionary<int, string>{ { 0, "Generic Plain Text" } })
+                    };
+                }
+            }
         }
     }
 }

--- a/MarkdigWrapper/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/MarkdigWrapper/SyntaxHighlightingCodeBlockRenderer.cs
@@ -55,7 +55,7 @@ namespace Markdig.SyntaxHighlighting {
             var languageTypeAdapter = new LanguageTypeAdapter();
             var language = languageTypeAdapter.Parse(languageMoniker, firstLine);
 
-            if (language == null) { //handle unrecognised language formats, e.g. when using mermaid diagrams
+            if (language?.Id == null) { // TODO: handle unrecognised language formats, e.g. when using mermaid diagrams
                 return code;
             }
 


### PR DESCRIPTION
### Before

Unknown language label => [raw, unformatted HTML][0]
 
![ANTE PATCHUM](https://user-images.githubusercontent.com/59004801/206835267-931c6ae0-1a4f-4be0-b25e-ca5994cc5631.png)

### After

Unknown language label => `<pre>`-formatted HTML (*1)
(*1) _At minimum &#x2014; the label has to be in the `ColorCode.Languages` dictionary to also get CSS styling_

![POST PATCHUM](https://user-images.githubusercontent.com/59004801/206835269-d7f528e3-4fbb-4c1c-81a2-a02cdeb8a703.png)

[0]: https://github.com/mohzy83/NppMarkdownPanel/blob/f061486098d0ccd1fdb9fb4706e43384dc8c5d1a/MarkdigWrapper/SyntaxHighlightingCodeBlockRenderer.cs#L58-L60
