### PR TITLE
Fix memory layout of `ScNotificationHeader`

### DIFF
--- a/NppMarkdownPanel/PluginInfrastructure/GatewayDomain.cs
+++ b/NppMarkdownPanel/PluginInfrastructure/GatewayDomain.cs
@@ -64,6 +64,19 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
     {
         private readonly int pos;
 
+        // TODO: support >2 GiB files (i.e, 64-bit character positions)
+        public Position(IntPtr pos)
+        {
+            try
+            {
+                this.pos = pos.ToInt32();
+            }
+            catch (OverflowException)
+            {
+                this.pos = -1;
+            }
+        }
+
         public Position(int pos)
         {
             this.pos = pos;

--- a/NppMarkdownPanel/PluginInfrastructure/Scintilla_iface.cs
+++ b/NppMarkdownPanel/PluginInfrastructure/Scintilla_iface.cs
@@ -38,21 +38,21 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
     public struct ScNotification
     {
         public ScNotificationHeader Header;
-        private int position;               /* SCN_STYLENEEDED, SCN_DOUBLECLICK, SCN_MODIFIED, SCN_MARGINCLICK, SCN_NEEDSHOWN, SCN_DWELLSTART, SCN_DWELLEND, SCN_CALLTIPCLICK, SCN_HOTSPOTCLICK, SCN_HOTSPOTDOUBLECLICK, SCN_HOTSPOTRELEASECLICK, SCN_INDICATORCLICK, SCN_INDICATORRELEASE, SCN_USERLISTSELECTION, SCN_AUTOCSELECTION */
+        private IntPtr position;            /* SCN_STYLENEEDED, SCN_DOUBLECLICK, SCN_MODIFIED, SCN_MARGINCLICK, SCN_NEEDSHOWN, SCN_DWELLSTART, SCN_DWELLEND, SCN_CALLTIPCLICK, SCN_HOTSPOTCLICK, SCN_HOTSPOTDOUBLECLICK, SCN_HOTSPOTRELEASECLICK, SCN_INDICATORCLICK, SCN_INDICATORRELEASE, SCN_USERLISTSELECTION, SCN_AUTOCSELECTION */
         public int character;               /* SCN_CHARADDED, SCN_KEY, SCN_AUTOCCOMPLETE, SCN_AUTOCSELECTION, SCN_USERLISTSELECTION */
         public int Mmodifiers;              /* SCN_KEY, SCN_DOUBLECLICK, SCN_HOTSPOTCLICK, SCN_HOTSPOTDOUBLECLICK, SCN_HOTSPOTRELEASECLICK, SCN_INDICATORCLICK, SCN_INDICATORRELEASE */
         public int ModificationType;        /* SCN_MODIFIED - modification types are name "SC_MOD_*" */
         public IntPtr TextPointer;          /* SCN_MODIFIED, SCN_USERLISTSELECTION, SCN_AUTOCSELECTION, SCN_URIDROPPED */
-        public int Length;                  /* SCN_MODIFIED */
-        public int LinesAdded;              /* SCN_MODIFIED */
+        public IntPtr Length;               /* SCN_MODIFIED */
+        public IntPtr LinesAdded;           /* SCN_MODIFIED */
         public int Message;                 /* SCN_MACRORECORD */
-        public IntPtr wParam;               /* SCN_MACRORECORD */
+        public UIntPtr wParam;              /* SCN_MACRORECORD */
         public IntPtr lParam;               /* SCN_MACRORECORD */
 
         /// <summary>
         /// 0-based index
         /// </summary>
-        public int LineNumber;           /* SCN_MODIFIED */
+        public IntPtr LineNumber;        /* SCN_MODIFIED */
         public int FoldLevelNow;         /* SCN_MODIFIED */
         public int FoldLevelPrev;        /* SCN_MODIFIED */
         public int Margin;               /* SCN_MARGINCLICK */
@@ -60,9 +60,10 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         public int X;                    /* SCN_DWELLSTART, SCN_DWELLEND */
         public int Y;                    /* SCN_DWELLSTART, SCN_DWELLEND */
         public int Token;                /* SCN_MODIFIED with SC_MOD_CONTAINER */
-        public int AnnotationLinesAdded; /* SC_MOD_CHANGEANNOTATION */
+        public IntPtr AnnotationLinesAdded; /* SC_MOD_CHANGEANNOTATION */
         public int Updated;              /* SCN_UPDATEUI */
         public int ListCompletionMethod; /* SCN_AUTOCSELECTION, SCN_AUTOCCOMPLETED, SCN_USERLISTSELECTION */
+        public int CharacterSource;      /* SCN_CHARADDED */
 
         /// <summary>
         /// SCN_STYLENEEDED, SCN_DOUBLECLICK, SCN_MODIFIED, SCN_MARGINCLICK, SCN_NEEDSHOWN, SCN_DWELLSTART, SCN_DWELLEND, SCN_CALLTIPCLICK, SCN_HOTSPOTCLICK, SCN_HOTSPOTDOUBLECLICK, SCN_HOTSPOTRELEASECLICK, SCN_INDICATORCLICK, SCN_INDICATORRELEASE, SCN_USERLISTSELECTION, SCN_AUTOCSELECTION


### PR DESCRIPTION
### Fixed

- [X] Synchronized fields with the C++ `struct` (where `Sci_Position` is a pointer-width integer): <https://www.scintilla.org/ScintillaDoc.html#SCNotification>

### Not (yet) fixed

- [ ] Character positions remain limited to 32-bit values; i.e., notifications will not work properly in files of >2 GiB: <https://community.notepad-plus-plus.org/post/73553>

- [ ] The strictly correct type of `ScNotificationHeader.IdFrom` is __*U*__&#x200D;`IntPtr` (to match [the `wParam` field][0]); but this will create a cascade of type errors in dependent modules

- [ ] The field name `Mmodifiers` (*sic*) remains misspelled; fixing it may break dependent modules


[0]: https://devblogs.microsoft.com/oldnewthing/20031125-00/?p=41713

