### PR TITLE
Fix Mermaid diagram rendering with class="mermaid" pre tags (fixes #115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+## Build
+```powershell
+.\build.ps1
+```
+Builds Release x86 and x64 via MSBuild. `Copy-Output-Debug-*.cmd` scripts deploy the DLL to the Notepad++ plugins folder for testing.
+
+## Architecture
+
+4 projects in `NppMarkdownPanel.sln`:
+| Project | Role |
+|---------|------|
+| `NppMarkdownPanel` | Notepad++ plugin DLL + Windows Forms UI |
+| `MarkdigWrapper` | Markdig pipeline: markdown → HTML with syntax highlighting |
+| `PanelCommon` | Shared interfaces: `IMarkdownGenerator`, `IWebbrowserControl` |
+| `Webview2Viewer` | Edge/Chromium WebView2 rendering engine |
+
+## Rendering Pipeline
+
+1. `MarkdownPanelController` detects Scintilla changes, debounces (400ms threshold, 500ms cycle)
+2. `MarkdownService.ConvertToHtml()` → optional pre-processor → `MarkdigMarkdownGenerator.ConvertToHtml()` → optional post-processor
+3. `MarkdigMarkdownGenerator` builds a pipeline with: AdvancedExtensions, YamlFrontMatter, SyntaxHighlighting, PreciseSourceLocation. Sets `id` attributes on every block for scroll sync.
+4. `MarkdownPreviewForm.RenderHtmlInternal()` wraps the HTML body in `DEFAULT_HTML_BASE` template
+5. `IWebbrowserControl.SetContent()` renders in the web view
+
+## Two Rendering Engines
+
+- **WebView2 (EDGE)** — `Webview2WebbrowserControl.cs` — default, modern browser features
+- **IE11 (WebView1)** — `IE11WebbrowserControl.cs` — legacy fallback, no Mermaid support
+
+Default engine set in `Settings.RenderingEngine = RENDERING_ENGINE_WEBVIEW2_EDGE`.
+
+## HTML Template
+
+Hardcoded in `NppMarkdownPanel/Forms/MarkdownPreviewForm.cs:DEFAULT_HTML_BASE`. Four `string.Format` placeholders: `{0}`=title, `{1}`=CSS, `{2}`=body style, `{3}`=body HTML. Scripts for Mermaid are embedded directly in the template.
+
+## Mermaid Diagrams
+
+- **Renderer**: `SyntaxHighlightingCodeBlockRenderer.cs` detects `mermaid` language, outputs `<pre class="mermaid">` (HTML-escaped, no syntax highlighting). Other fenced code blocks get syntax-highlighted `<div>` wrappers.
+- **JS library**: Mermaid v10 loaded via CDN (`jsdelivr`) in the HTML template `<head>`. Initialized with `startOnLoad: false`, then `mermaid.run()` is called at end of `<body>`.
+- **WebView2 partial updates**: After dynamic `document.body.innerHTML` injection, `mermaid.run()` is called again via `ExecuteScriptAsync`.
+- **IE11**: Mermaid v10 does not support IE11. Diagrams silently fail to render (not an error).
+
+## Key File Locations
+
+- HTML template: `NppMarkdownPanel/Forms/MarkdownPreviewForm.cs:19`
+- Mermaid renderer logic: `MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs:44`
+- Markdig pipeline: `MarkdigWrapper/MarkdigMarkdownGenerator.cs:30`
+- WebView2 body update + Mermaid re-run: `Webview2Viewer/Webview2WebbrowserControl.cs:198`
+- Scroll sync JS injection: `Webview2Viewer/Webview2WebbrowserControl.cs:126`
+- Settings entity: `NppMarkdownPanel/Entities/Settings.cs`
+- Notepad++ integration: `NppMarkdownPanel/PluginInfrastructure/`
+
+## CSS
+
+- `NppMarkdownPanel/style.css` — light theme
+- `NppMarkdownPanel/style-dark.css` — dark theme
+- Users can override via custom CSS file path in settings
+
+## Test Files
+
+- `NppMarkdownPanel/Resources/nppMdP.tests/` — sample `.md` and `.html` files
+- Test Mermaid: `Test-MD.md` — general test; embed ```mermaid blocks in any test file to verify rendering

--- a/MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -35,11 +35,18 @@ namespace Markdig.SyntaxHighlighting
 
             var languageMoniker = fencedCodeBlock.Info.Replace(parser.InfoPrefix, string.Empty);
 
-            if (string.IsNullOrEmpty(languageMoniker)
-                // skip syntax highlighting for mermaid - leave block as pre tag which allows "mermaid JS" to render the codeblock as graph
-                || string.Equals(languageMoniker, LanguageTypeAdapter.LANGUAGE_KEY_MERMAID, StringComparison.OrdinalIgnoreCase))
+            if (string.IsNullOrEmpty(languageMoniker))
             {
                 _underlyingRenderer.Write(renderer, obj);
+                return;
+            }
+
+            if (string.Equals(languageMoniker, LanguageTypeAdapter.LANGUAGE_KEY_MERMAID, StringComparison.OrdinalIgnoreCase))
+            {
+                var mermaidCode = GetCode(obj, out _);
+                renderer.Write("<pre class=\"mermaid\">");
+                renderer.WriteEscape(mermaidCode);
+                renderer.WriteLine("</pre>");
                 return;
             }
 

--- a/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
+++ b/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
@@ -26,9 +26,16 @@ namespace NppMarkdownPanel.Forms
                     <style type=""text/css"">
                     {1}
                     </style>
+                    <script src=""https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js""></script>
+                    <script>
+                    mermaid.initialize({{ startOnLoad: false }});
+                    </script>
                 </head>
                 <body class=""markdown-body"" style=""{2}"">
                 {3}
+                <script>
+                mermaid.run();
+                </script>
                 </body>
             </html>
             ";

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -195,6 +195,7 @@ namespace Webview2Viewer
                     ExecuteWebviewAction(new Action(async () =>
                     {
                         await webView.ExecuteScriptAsync("document.body.innerHTML = '" + HttpUtility.JavaScriptStringEncode(currentBody) + "'");
+                        await webView.ExecuteScriptAsync("if(typeof mermaid!=='undefined'){mermaid.run();}");
                     }));
                 }
                 if (currentStyle != style)


### PR DESCRIPTION
- Mermaid fenced code blocks now render as `<pre class="mermaid">` instead of `<pre><code>`
- Added Mermaid.js v10 via CDN with `startOnLoad: false` + `mermaid.run()` in the HTML template
- Added `mermaid.run()` call after WebView2 dynamic body updates for live editing

Closes #115