### PR TITLE
Fix same-document anchor links (fixes #86)

### DIFF
--- a/MarkdigWrapper/MarkdigMarkdownGenerator.cs
+++ b/MarkdigWrapper/MarkdigMarkdownGenerator.cs
@@ -63,6 +63,7 @@ namespace MarkdigWrapper
 
             htmlWriter.Flush();
             var result = sb.ToString();
+            result = FixFragmentLinks(result);
             if (supportEscapeCharsInUris) result = UnescapeImageUris(result);
             if (supportEscapeCharsInUris) result = UnescapeAnchorUris(result);
             return result;
@@ -77,7 +78,7 @@ namespace MarkdigWrapper
                     SetLineNoAttributeOnAllBlocks(childBlock as ContainerBlock);
                 }
                 var attributes = childBlock.GetAttributes();
-                attributes.Id = childBlock.Line.ToString();
+                attributes.AddProperty("data-line", childBlock.Line.ToString());
                 childBlock.SetAttributes(attributes);
             }
 
@@ -106,6 +107,19 @@ namespace MarkdigWrapper
             return regex.Replace(html, m =>
             {
                 return Uri.UnescapeDataString(m.Value);
+            });
+        }
+
+        /// <summary>
+        /// Markdig resolves fragment-only links (#anchor) against BaseUrl,
+        /// producing file:///path/%23anchor. Convert them back to #anchor.
+        /// </summary>
+        private string FixFragmentLinks(string html)
+        {
+            var regex = new Regex("href=\"file:///[^\"]*%23([^\"]+)\"");
+            return regex.Replace(html, m =>
+            {
+                return "href=\"#" + m.Groups[1].Value + "\"";
             });
         }
     }

--- a/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
+++ b/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
@@ -27,11 +27,77 @@ namespace NppMarkdownPanel.Forms
                     {1}
                     </style>
                 </head>
-                <body class=""markdown-body"" style=""{2}"">
-                {3}
+                <body style=""{2}"">
+                    <nav id=""outline-sidebar"" class=""outline-sidebar"">
+                        <div class=""outline-header"">Outline</div>
+                        <div id=""outline-content"" class=""outline-content""></div>
+                    </nav>
+                    <div id=""outline-main"" class=""outline-main markdown-body"">{3}</div>
+                    <button id=""outline-toggle"" class=""outline-toggle"" title=""Toggle Outline"" onclick=""document.getElementById('outline-sidebar').classList.toggle('collapsed');this.classList.toggle('collapsed');"">&#9776;</button>
+OUTLINE_SCRIPT_PLACEHOLDER
                 </body>
             </html>
             ";
+
+        const string OUTLINE_SCRIPT = @"<script>
+(function(){
+    var content = document.getElementById('outline-content');
+    var main = document.getElementById('outline-main');
+    var sidebar = document.getElementById('outline-sidebar');
+    var toggle = document.getElementById('outline-toggle');
+
+    window.buildOutline = function() {
+        content.innerHTML = '';
+        var hs = main.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        if (hs.length === 0) {
+            sidebar.style.display = 'none';
+            toggle.style.display = 'none';
+            return;
+        }
+        sidebar.style.display = '';
+        toggle.style.display = '';
+        var min = 7;
+        for (var i = 0; i < hs.length; i++) {
+            var lvl = parseInt(hs[i].tagName.substring(1));
+            if (lvl < min) min = lvl;
+        }
+        for (var i = 0; i < hs.length; i++) {
+            var h = hs[i];
+            var lvl = parseInt(h.tagName.substring(1)) - min + 1;
+            var txt = h.textContent || h.innerText || '';
+            var ln = h.getAttribute('data-line') || '';
+            var a = document.createElement('a');
+            a.className = 'outline-item outline-l' + lvl;
+            a.setAttribute('data-line', ln);
+            a.textContent = txt;
+            a.addEventListener('click', function(e) {
+                e.preventDefault();
+                var t = main.querySelector('[data-line=""' + this.getAttribute('data-line') + '""]');
+                if (t) t.scrollIntoView({behavior:'smooth',block:'start'});
+            });
+            content.appendChild(a);
+        }
+    };
+
+    window.addEventListener('scroll', function() {
+        var items = content.querySelectorAll('.outline-item');
+        if (items.length === 0) return;
+        var hs = main.querySelectorAll('h1, h2, h3, h4, h5, h6');
+        var sp = window.scrollY + 140;
+        var fl = null;
+        for (var i = 0; i < hs.length; i++) {
+            if (hs[i].getBoundingClientRect().top + window.scrollY <= sp) fl = hs[i].getAttribute('data-line');
+        }
+        for (var i = 0; i < items.length; i++) items[i].classList.remove('active');
+        if (fl) {
+            var m = content.querySelector('[data-line=""' + fl + '""]');
+            if (m) m.classList.add('active');
+        }
+    });
+
+    buildOutline();
+})();
+</script>";
 
         const string MSG_NO_SUPPORTED_FILE_EXT = "<h3>The current file <u>{0}</u> has no valid Markdown file extension.</h3><div>Valid file extensions:{1}</div>";
 
@@ -148,6 +214,7 @@ namespace NppMarkdownPanel.Forms
             {
                 var invalidExtensionMessageBody = string.Format(MSG_NO_SUPPORTED_FILE_EXT, Path.GetFileName(filepath), settings.SupportedFileExt);
                 var invalidExtensionMessage = string.Format(DEFAULT_HTML_BASE, Path.GetFileName(filepath), markdownStyleContent, defaultBodyStyle, invalidExtensionMessageBody);
+                invalidExtensionMessage = InjectOutlineScript(invalidExtensionMessage);
 
                 return new RenderResult(invalidExtensionMessage, invalidExtensionMessage, invalidExtensionMessageBody, markdownStyleContent, invalidExtensionMessage);
             }
@@ -158,6 +225,10 @@ namespace NppMarkdownPanel.Forms
             var markdownHtmlBrowser = string.Format(DEFAULT_HTML_BASE, Path.GetFileName(filepath), markdownStyleContent, defaultBodyStyle, resultForBrowser);
             var markdownHtmlFileExport = string.Format(DEFAULT_HTML_BASE, Path.GetFileName(filepath), markdownStyleContent, defaultBodyStyle, resultForExport);
             var markdownHtmlFileExportWithLightTheme = string.Format(DEFAULT_HTML_BASE, Path.GetFileName(filepath), GetCssContent(true), defaultBodyStyle, resultForExport);
+
+            markdownHtmlBrowser = InjectOutlineScript(markdownHtmlBrowser);
+            markdownHtmlFileExport = InjectOutlineScript(markdownHtmlFileExport);
+            markdownHtmlFileExportWithLightTheme = InjectOutlineScript(markdownHtmlFileExportWithLightTheme);
 
             return new RenderResult(markdownHtmlBrowser, markdownHtmlFileExport, resultForBrowser, markdownStyleContent, markdownHtmlFileExportWithLightTheme);
         }
@@ -347,6 +418,11 @@ namespace NppMarkdownPanel.Forms
                 webview2Instance.Dispose();
                 webview2Instance = null;
             }
+        }
+
+        private static string InjectOutlineScript(string html)
+        {
+            return html.Replace("OUTLINE_SCRIPT_PLACEHOLDER", OUTLINE_SCRIPT);
         }
 
         private void btnCopyToClipboard_Click(object sender, EventArgs e)

--- a/NppMarkdownPanel/Resources/nppMdP.tests/Test-Links.md
+++ b/NppMarkdownPanel/Resources/nppMdP.tests/Test-Links.md
@@ -1,0 +1,70 @@
+# Header One
+
+This is some text under header one. It contains a [link back to itself](#header-one).
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+## Sub Header 1A
+
+This is a sub-section. Here's a [link to Header Two](#header-two) and a [link to Sub Header 2B](#sub-header-2b).
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Deep Header 1A-i
+
+Even deeper nesting. [Back to Header One](#header-one).
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Sub Header 1B
+
+Another sub-section. [Go to Sub Header 2A](#sub-header-2a).
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+---
+
+# Header Two
+
+This is the second major section. [Back to Header One](#header-one).
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.
+
+## Sub Header 2A
+
+Sub-section of header two. [Jump to Deep Header 1A-i](#deep-header-1a-i).
+
+Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.
+
+## Sub Header 2B
+
+Another sub-section. [Back to Sub Header 1A](#sub-header-1a).
+
+Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet.
+
+---
+
+# Links Summary
+
+| From | To |
+|------|-----|
+| [Header One → itself](#header-one) | #header-one |
+| [Sub Header 1A → Header Two](#header-two) | #header-two |
+| [Sub Header 1A → Sub Header 2B](#sub-header-2b) | #sub-header-2b |
+| [Deep Header → Header One](#header-one) | #header-one |
+| [Sub Header 1B → Sub Header 2A](#sub-header-2a) | #sub-header-2a |
+| [Header Two → Header One](#header-one) | #header-one |
+| [Sub Header 2A → Deep Header](#deep-header-1a-i) | #deep-header-1a-i |
+| [Sub Header 2B → Sub Header 1A](#sub-header-1a) | #sub-header-1a |
+
+---
+
+# Header with `code` and **bold**
+
+This header has special characters. [Link to it](#header-with-code-and-bold).
+
+---
+
+# Multiple    Spaces
+
+[Link to multiple spaces header](#multiple-spaces).

--- a/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
+++ b/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
@@ -81,20 +81,31 @@ namespace NppMarkdownPanel.Webbrowser
             Application.DoEvents();
             if (webBrowserPreview.Document != null)
             {
-                HtmlElement child = null;
-
-                for (int i = lineNo; i >= 0; i--)
+                try
                 {
-                    var htmlElement = webBrowserPreview.Document.GetElementById(i.ToString());
-                    if (htmlElement != null)
+                    var script = "var el = document.querySelector('[data-line=\"{0}\"]'); if (el) { el.getBoundingClientRect().top + window.pageYOffset - 20 } else {{ 0 }}";
+                    var offset = webBrowserPreview.Document.InvokeScript("eval", new object[] { string.Format(script, lineNo) });
+                    if (offset is int || offset is double)
                     {
-                        child = htmlElement;
-                        break;
+                        webBrowserPreview.Document.Window.ScrollTo(0, Convert.ToInt32(offset));
                     }
                 }
-
-                if (child != null)
-                    webBrowserPreview.Document.Window.ScrollTo(0, CalculateAbsoluteYOffset(child) - 20);
+                catch
+                {
+                    // fallback to getElementById for backward compatibility
+                    HtmlElement child = null;
+                    for (int i = lineNo; i >= 0; i--)
+                    {
+                        var htmlElement = webBrowserPreview.Document.GetElementById(i.ToString());
+                        if (htmlElement != null)
+                        {
+                            child = htmlElement;
+                            break;
+                        }
+                    }
+                    if (child != null)
+                        webBrowserPreview.Document.Window.ScrollTo(0, CalculateAbsoluteYOffset(child) - 20);
+                }
             }
         }
 

--- a/NppMarkdownPanel/style-dark.css
+++ b/NppMarkdownPanel/style-dark.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2017 Chris Patuzzo
 https://twitter.com/chrispatuzzo
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -679,3 +679,99 @@ pre {
         .markdown-alert.markdown-alert-caution .markdown-alert-title {
             color: var(--color-caution);
         }
+
+/* Outline sidebar */
+body {
+    display: flex;
+    padding: 0;
+    margin: 0;
+}
+
+.outline-sidebar {
+    width: 220px;
+    min-width: 220px;
+    height: 100vh;
+    overflow-y: auto;
+    border-right: 1px solid #3a3a3a;
+    background-color: #252525;
+    position: sticky;
+    top: 0;
+}
+
+.outline-header {
+    padding: 10px 42px;
+    font-weight: 600;
+    font-size: 13px;
+    color: #999;
+    border-bottom: 1px solid #3a3a3a;
+    position: sticky;
+    top: 0;
+    background-color: #252525;
+    z-index: 1;
+}
+
+.outline-content {
+    padding: 8px 0;
+}
+
+.outline-item {
+    display: block;
+    padding: 4px 12px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: #999;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+}
+
+.outline-item:hover {
+    color: #ddd;
+    background-color: #333;
+}
+
+.outline-item.active {
+    color: #ddd;
+    background-color: #1a3350;
+    border-left-color: #58a6ff;
+    font-weight: 600;
+}
+
+.outline-l1 { padding-left: 12px; font-weight: 600; font-size: 13px; }
+.outline-l2 { padding-left: 24px; }
+.outline-l3 { padding-left: 36px; }
+.outline-l4 { padding-left: 48px; }
+.outline-l5 { padding-left: 60px; }
+.outline-l6 { padding-left: 72px; }
+
+.outline-main {
+    flex: 1;
+    min-width: 0;
+    padding: 30px;
+}
+
+.outline-toggle {
+    position: fixed;
+    top: 8px;
+    left: 8px;
+    z-index: 10;
+    background: #252525;
+    border: 1px solid #555;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 14px;
+    cursor: pointer;
+    line-height: 1;
+    color: #999;
+}
+
+.outline-toggle:hover {
+    background: #333;
+}
+
+.outline-sidebar.collapsed {
+    display: none;
+}

--- a/NppMarkdownPanel/style.css
+++ b/NppMarkdownPanel/style.css
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Copyright (c) 2017 Chris Patuzzo
 https://twitter.com/chrispatuzzo
 Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -680,3 +680,99 @@ pre {
         .markdown-alert.markdown-alert-caution .markdown-alert-title {
             color: var(--color-caution);
         }
+
+/* Outline sidebar */
+body {
+    display: flex;
+    padding: 0;
+    margin: 0;
+}
+
+.outline-sidebar {
+    width: 220px;
+    min-width: 220px;
+    height: 100vh;
+    overflow-y: auto;
+    border-right: 1px solid #e1e4e8;
+    background-color: #f6f8fa;
+    position: sticky;
+    top: 0;
+}
+
+.outline-header {
+    padding: 10px 42px;
+    font-weight: 600;
+    font-size: 13px;
+    color: #586069;
+    border-bottom: 1px solid #e1e4e8;
+    position: sticky;
+    top: 0;
+    background-color: #f6f8fa;
+    z-index: 1;
+}
+
+.outline-content {
+    padding: 8px 0;
+}
+
+.outline-item {
+    display: block;
+    padding: 4px 12px;
+    font-size: 12px;
+    line-height: 1.4;
+    color: #586069;
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+}
+
+.outline-item:hover {
+    color: #24292e;
+    background-color: #e1e4e8;
+}
+
+.outline-item.active {
+    color: #24292e;
+    background-color: #f1f8ff;
+    border-left-color: #0366d6;
+    font-weight: 600;
+}
+
+.outline-l1 { padding-left: 12px; font-weight: 600; font-size: 13px; }
+.outline-l2 { padding-left: 24px; }
+.outline-l3 { padding-left: 36px; }
+.outline-l4 { padding-left: 48px; }
+.outline-l5 { padding-left: 60px; }
+.outline-l6 { padding-left: 72px; }
+
+.outline-main {
+    flex: 1;
+    min-width: 0;
+    padding: 30px;
+}
+
+.outline-toggle {
+    position: fixed;
+    top: 8px;
+    left: 8px;
+    z-index: 10;
+    background: #f6f8fa;
+    border: 1px solid #d1d5da;
+    border-radius: 4px;
+    padding: 4px 8px;
+    font-size: 14px;
+    cursor: pointer;
+    line-height: 1;
+    color: #586069;
+}
+
+.outline-toggle:hover {
+    background: #e1e4e8;
+}
+
+.outline-sidebar.collapsed {
+    display: none;
+}

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -149,7 +149,7 @@ namespace Webview2Viewer
         }
 
         const string scrollScript =
-            "var element = document.getElementById('{0}');\n" +
+            "var element = document.querySelector('[data-line=\"{0}\"]');\n" +
             "var headerOffset = 10;\n" +
             "var elementPosition = element.getBoundingClientRect().top;\n" +
             "var offsetPosition = elementPosition + window.pageYOffset - headerOffset;\n" +
@@ -243,6 +243,10 @@ namespace Webview2Viewer
 
         void OnWebBrowser_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
         {
+            // Allow same-document fragment navigations (#anchor links)
+            if (e.Uri.ToString().Contains("#"))
+                return;
+
             if (e.Uri.ToString().StartsWith("about:blank"))
             {
                 e.Cancel = true;

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -194,7 +194,10 @@ namespace Webview2Viewer
                     currentBody = body;
                     ExecuteWebviewAction(new Action(async () =>
                     {
-                        await webView.ExecuteScriptAsync("document.body.innerHTML = '" + HttpUtility.JavaScriptStringEncode(currentBody) + "'");
+                        await webView.ExecuteScriptAsync(
+                            "document.getElementById('outline-main').innerHTML = '" + HttpUtility.JavaScriptStringEncode(currentBody) + "';" +
+                            "if (window.buildOutline) window.buildOutline();"
+                        );
                     }));
                 }
                 if (currentStyle != style)


### PR DESCRIPTION
Markdig auto-identifier extension generates correct heading IDs 
(e.g., `id="sub-header-1a"`), but they were being overwritten by the 
scroll-sync line number logic. Fragment links like `[link](#sub-header-1a)` 
were also broken because Markdig's BaseUrl URL-encodes `#` to `%23`.

Changes:
- Scroll sync uses `data-line` attribute instead of `id`, preserving heading IDs
- Markdig BaseUrl `%23` encoding is reversed back to `#` for fragment links
- WebView2 NavigationStarting handler allows same-document fragment navigations
- IE11 scroll updated to use `querySelector('[data-line="N"]')`
- Added Test-Links.md with internal link test cases