### PR TITLE
Fix same-document anchor links (#86)

### DIFF
--- a/MarkdigWrapper/MarkdigMarkdownGenerator.cs
+++ b/MarkdigWrapper/MarkdigMarkdownGenerator.cs
@@ -63,6 +63,7 @@ namespace MarkdigWrapper
 
             htmlWriter.Flush();
             var result = sb.ToString();
+            result = FixFragmentLinks(result);
             if (supportEscapeCharsInUris) result = UnescapeImageUris(result);
             if (supportEscapeCharsInUris) result = UnescapeAnchorUris(result);
             return result;
@@ -77,7 +78,7 @@ namespace MarkdigWrapper
                     SetLineNoAttributeOnAllBlocks(childBlock as ContainerBlock);
                 }
                 var attributes = childBlock.GetAttributes();
-                attributes.Id = childBlock.Line.ToString();
+                attributes.AddProperty("data-line", childBlock.Line.ToString());
                 childBlock.SetAttributes(attributes);
             }
 
@@ -106,6 +107,19 @@ namespace MarkdigWrapper
             return regex.Replace(html, m =>
             {
                 return Uri.UnescapeDataString(m.Value);
+            });
+        }
+
+        /// <summary>
+        /// Markdig resolves fragment-only links (#anchor) against BaseUrl,
+        /// producing file:///path/%23anchor. Convert them back to #anchor.
+        /// </summary>
+        private string FixFragmentLinks(string html)
+        {
+            var regex = new Regex("href=\"file:///[^\"]*%23([^\"]+)\"");
+            return regex.Replace(html, m =>
+            {
+                return "href=\"#" + m.Groups[1].Value + "\"";
             });
         }
     }

--- a/NppMarkdownPanel/Resources/nppMdP.tests/Test-Links.md
+++ b/NppMarkdownPanel/Resources/nppMdP.tests/Test-Links.md
@@ -1,0 +1,70 @@
+# Header One
+
+This is some text under header one. It contains a [link back to itself](#header-one).
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+## Sub Header 1A
+
+This is a sub-section. Here's a [link to Header Two](#header-two) and a [link to Sub Header 2B](#sub-header-2b).
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+### Deep Header 1A-i
+
+Even deeper nesting. [Back to Header One](#header-one).
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Sub Header 1B
+
+Another sub-section. [Go to Sub Header 2A](#sub-header-2a).
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+---
+
+# Header Two
+
+This is the second major section. [Back to Header One](#header-one).
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium.
+
+## Sub Header 2A
+
+Sub-section of header two. [Jump to Deep Header 1A-i](#deep-header-1a-i).
+
+Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit.
+
+## Sub Header 2B
+
+Another sub-section. [Back to Sub Header 1A](#sub-header-1a).
+
+Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet.
+
+---
+
+# Links Summary
+
+| From | To |
+|------|-----|
+| [Header One → itself](#header-one) | #header-one |
+| [Sub Header 1A → Header Two](#header-two) | #header-two |
+| [Sub Header 1A → Sub Header 2B](#sub-header-2b) | #sub-header-2b |
+| [Deep Header → Header One](#header-one) | #header-one |
+| [Sub Header 1B → Sub Header 2A](#sub-header-2a) | #sub-header-2a |
+| [Header Two → Header One](#header-one) | #header-one |
+| [Sub Header 2A → Deep Header](#deep-header-1a-i) | #deep-header-1a-i |
+| [Sub Header 2B → Sub Header 1A](#sub-header-1a) | #sub-header-1a |
+
+---
+
+# Header with `code` and **bold**
+
+This header has special characters. [Link to it](#header-with-code-and-bold).
+
+---
+
+# Multiple    Spaces
+
+[Link to multiple spaces header](#multiple-spaces).

--- a/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
+++ b/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
@@ -81,20 +81,31 @@ namespace NppMarkdownPanel.Webbrowser
             Application.DoEvents();
             if (webBrowserPreview.Document != null)
             {
-                HtmlElement child = null;
-
-                for (int i = lineNo; i >= 0; i--)
+                try
                 {
-                    var htmlElement = webBrowserPreview.Document.GetElementById(i.ToString());
-                    if (htmlElement != null)
+                    var script = "var el = document.querySelector('[data-line=\"{0}\"]'); if (el) { el.getBoundingClientRect().top + window.pageYOffset - 20 } else {{ 0 }}";
+                    var offset = webBrowserPreview.Document.InvokeScript("eval", new object[] { string.Format(script, lineNo) });
+                    if (offset is int || offset is double)
                     {
-                        child = htmlElement;
-                        break;
+                        webBrowserPreview.Document.Window.ScrollTo(0, Convert.ToInt32(offset));
                     }
                 }
-
-                if (child != null)
-                    webBrowserPreview.Document.Window.ScrollTo(0, CalculateAbsoluteYOffset(child) - 20);
+                catch
+                {
+                    // fallback to getElementById for backward compatibility
+                    HtmlElement child = null;
+                    for (int i = lineNo; i >= 0; i--)
+                    {
+                        var htmlElement = webBrowserPreview.Document.GetElementById(i.ToString());
+                        if (htmlElement != null)
+                        {
+                            child = htmlElement;
+                            break;
+                        }
+                    }
+                    if (child != null)
+                        webBrowserPreview.Document.Window.ScrollTo(0, CalculateAbsoluteYOffset(child) - 20);
+                }
             }
         }
 

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -149,7 +149,7 @@ namespace Webview2Viewer
         }
 
         const string scrollScript =
-            "var element = document.getElementById('{0}');\n" +
+            "var element = document.querySelector('[data-line=\"{0}\"]');\n" +
             "var headerOffset = 10;\n" +
             "var elementPosition = element.getBoundingClientRect().top;\n" +
             "var offsetPosition = elementPosition + window.pageYOffset - headerOffset;\n" +
@@ -243,6 +243,10 @@ namespace Webview2Viewer
 
         void OnWebBrowser_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
         {
+            // Allow same-document fragment navigations (#anchor links)
+            if (e.Uri.ToString().Contains("#"))
+                return;
+
             if (e.Uri.ToString().StartsWith("about:blank"))
             {
                 e.Cancel = true;


### PR DESCRIPTION
- Use data-line attribute instead of id for scroll sync, preserving Markdig auto-generated heading IDs (e.g. id=sub-header-1a)
- Fix fragment links: Markdig encodes # to %23 when BaseUrl is set; convert %23 back to # in href attributes
- Allow fragment-only navigations in WebView2 NavigationStarting handler
- Update IE11 scroll sync to use querySelector with data-line
- Add Test-Links.md with internal link test cases