### PR TITLE
Fix: resolve relative paths in raw HTML `<img>` / `<a>` tags (fixes #84)

### DIFF
--- a/MarkdigWrapper/MarkdigMarkdownGenerator.cs
+++ b/MarkdigWrapper/MarkdigMarkdownGenerator.cs
@@ -68,6 +68,7 @@ namespace MarkdigWrapper
                 htmlWriter.Flush();
                 result = sb.ToString();
                 result = FixFragmentLinks(result);
+                if (filepath != null) result = ResolveRelativePaths(result, filepath);
             }
             catch (Exception e)
             {
@@ -130,6 +131,46 @@ namespace MarkdigWrapper
             return regex.Replace(html, m =>
             {
                 return "href=\"#" + m.Groups[1].Value + "\"";
+            });
+        }
+
+        private string ResolveRelativePaths(string html, string baseFilePath)
+        {
+            if (string.IsNullOrEmpty(baseFilePath)) return html;
+
+            string baseDir;
+            try
+            {
+                baseDir = Path.GetDirectoryName(baseFilePath);
+                if (string.IsNullOrEmpty(baseDir)) return html;
+            }
+            catch
+            {
+                return html;
+            }
+
+            var regex = new Regex(
+                @"(src|href)\s*=\s*[""']((?!\s*(?:https?|ftp|file|data|about|mailto|javascript):|//)[^""']+)[""']",
+                RegexOptions.IgnoreCase
+            );
+
+            return regex.Replace(html, match =>
+            {
+                var attribute = match.Groups[1].Value;
+                var relativePath = match.Groups[2].Value;
+
+                if (string.IsNullOrWhiteSpace(relativePath) || relativePath.StartsWith("#"))
+                    return match.Value;
+
+                try
+                {
+                    var absolutePath = Path.GetFullPath(Path.Combine(baseDir, relativePath));
+                    return attribute + "=\"file:///" + absolutePath.Replace('\\', '/') + "\"";
+                }
+                catch
+                {
+                    return match.Value;
+                }
             });
         }
     }

--- a/NppMarkdownPanel/Resources/nppMdP.tests/Test-MD.md
+++ b/NppMarkdownPanel/Resources/nppMdP.tests/Test-MD.md
@@ -42,6 +42,8 @@ text `and code ` . . .
  `![tst (1).png](test%20nonAscii%20path\tst%20(1).png?raw=1  "tst (1).png" ){width="20px"}`
 (`?raw=1` works in some clouds)
 
+<img src="./test%20nonAscii%20path/tst%20(1).png" width="10%" height="5%" alt="Some text"/>
+
 #### HTTP image
 
 ![uUSB for power only](https://andrzejq.github.io/El_Prog/assets/img/Mikro-USB.png "uUSB for power only"){style="width:33%;"}  
@@ -49,7 +51,7 @@ text `and code ` . . .
 
 - - - - -
 
-#### Tabels
+#### Tables
 
 header | _Pipe_ | table
 -------|-------:|:-----:


### PR DESCRIPTION
Fixes #84 : Relative paths in raw HTML tags (e.g. `<img src="./image.png">`) were not resolved, unlike Markdown `![]()` syntax which worked correctly.

## Problem

When using raw HTML `<img>` tags with relative paths in the Markdown preview, images failed to load. For example:

```html
<img src="./someimage.png" width="10%" height="10%" alt="Some text"/>