### PR TITLE
Add PDF export feature (fixes #153)

### DIFF
--- a/NppMarkdownPanel/Forms/IViewerInterface.cs
+++ b/NppMarkdownPanel/Forms/IViewerInterface.cs
@@ -12,5 +12,6 @@ namespace NppMarkdownPanel.Forms
         void ScrollToElementWithLineNo(int lineNo);
         bool IsValidFileExtension(string filename);
         void Cleanup();
+        void ExportToPdf();
     }
 }

--- a/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
+++ b/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
@@ -360,5 +360,20 @@ namespace NppMarkdownPanel.Forms
         {
             ClipboardHelper.CopyToClipboard(htmlContentForExport, htmlContentForExport);
         }
+
+        public void ExportToPdf()
+        {
+            using (SaveFileDialog saveFileDialog = new SaveFileDialog())
+            {
+                saveFileDialog.Filter = "pdf files (*.pdf)|*.pdf";
+                saveFileDialog.RestoreDirectory = true;
+                saveFileDialog.InitialDirectory = Path.GetDirectoryName(currentFilePath);
+                saveFileDialog.FileName = Path.GetFileNameWithoutExtension(currentFilePath);
+                if (saveFileDialog.ShowDialog() == DialogResult.OK)
+                {
+                    webbrowserControl.ExportToPdf(saveFileDialog.FileName);
+                }
+            }
+        }
     }
 }

--- a/NppMarkdownPanel/MarkdownPanelController.cs
+++ b/NppMarkdownPanel/MarkdownPanelController.cs
@@ -258,6 +258,8 @@ namespace NppMarkdownPanel
             PluginBase.SetCommand(5, "&Settings", EditSettings);
             PluginBase.SetCommand(6, "&Help", ShowHelp);
             PluginBase.SetCommand(7, "&About", ShowAboutDialog);
+            PluginBase.SetCommand(8, "---", null);
+            PluginBase.SetCommand(9, "Export to &PDF", ExportToPdf);
             idMyDlg = 0;
         }
 
@@ -363,6 +365,11 @@ namespace NppMarkdownPanel
         {
             var aboutDialog = new AboutForm();
             aboutDialog.ShowDialog();
+        }
+
+        private void ExportToPdf()
+        {
+            viewerInterface.ExportToPdf();
         }
 
         private bool initDialog;

--- a/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
+++ b/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
@@ -216,5 +216,16 @@ namespace NppMarkdownPanel.Webbrowser
         {
 
         }
+
+        public void ExportToPdf(string filePath)
+        {
+            if (!IsInitialized()) return;
+            try
+            {
+                var browser = (SHDocVw.IWebBrowser2)webBrowserPreview.ActiveXInstance;
+                browser.ExecWB(OLECMDID.OLECMDID_PRINT, OLECMDEXECOPT.OLECMDEXECOPT_PROMPTUSER, IntPtr.Zero, IntPtr.Zero);
+            }
+            catch { }
+        }
     }
 }

--- a/PanelCommon/IWebbrowserControl.cs
+++ b/PanelCommon/IWebbrowserControl.cs
@@ -29,5 +29,7 @@ namespace PanelCommon
         bool IsInitialized();
 
         void StopScrollPositionTracking();
+
+        void ExportToPdf(string filePath);
     }
 }

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -298,7 +298,6 @@ namespace Webview2Viewer
         {
             string message = e.TryGetWebMessageAsString();
 
-            // Parse die JSON-Nachricht
             var splittedParams = message.Split(';');
             if (splittedParams.Length > 1)
             {
@@ -340,6 +339,14 @@ namespace Webview2Viewer
             blockScrollUpdates = true;
         }
 
+        public async void ExportToPdf(string filePath)
+        {
+            if (!IsInitialized()) return;
+            ExecuteWebviewAction(new Action(async () =>
+            {
+                await webView.CoreWebView2.PrintToPdfAsync(filePath);
+            }));
+        }
 
     }
 }


### PR DESCRIPTION
Adds PDF export for the rendered Markdown preview.

- WebView2 (Edge): Uses `CoreWebView2.PrintToPdfAsync()` for direct PDF save
- IE11: Falls back to system Print dialog (Microsoft Print to PDF)

Accessible via: Plugins → MarkdownPanel → Export to PDF

Changes:
- `IWebbrowserControl`: Added `ExportToPdf(string filePath)`
- `Webview2WebbrowserControl`: PrintToPdfAsync implementation
- `IE11WebbrowserControl`: ExecWB(OLECMDID_PRINT) fallback
- `MarkdownPreviewForm`: SaveFileDialog + ExportToPdf()
- `MarkdownPanelController`: Menu command at index 8-9

Closes #153