### PR TITLE
feat: add checkbox and radio toggle in preview pane (#7)

### DIFF
--- a/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
+++ b/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
@@ -53,6 +53,26 @@ namespace NppMarkdownPanel.Forms
         private IWebbrowserControl webview1Instance;
         private IWebbrowserControl webview2Instance;
         private bool cleanupStarted;
+        private Action<int> checkboxToggleHandler;
+        private Action<int> radioToggleHandler;
+
+        public void SetCheckboxToggleHandler(Action<int> handler)
+        {
+            checkboxToggleHandler = handler;
+            if (webbrowserControl != null)
+            {
+                webbrowserControl.CheckboxToggleAction = handler;
+            }
+        }
+
+        public void SetRadioToggleHandler(Action<int> handler)
+        {
+            radioToggleHandler = handler;
+            if (webbrowserControl != null)
+            {
+                webbrowserControl.RadioToggleAction = handler;
+            }
+        }
 
         public void UpdateSettings(Settings newSettings)
         {
@@ -144,6 +164,8 @@ namespace NppMarkdownPanel.Forms
             webbrowserControl.AddToHost(panel1);
             webbrowserControl.RenderingDoneAction = () => { HideScreenshotAndShowBrowser(); };
             webbrowserControl.StatusTextChangedAction = (status) => { toolStripStatusLabel1.Text = status; };
+            webbrowserControl.CheckboxToggleAction = checkboxToggleHandler;
+            webbrowserControl.RadioToggleAction = radioToggleHandler;
         }
 
         private RenderResult RenderHtmlInternal(string currentText, string filepath)

--- a/NppMarkdownPanel/MarkdownPanelController.cs
+++ b/NppMarkdownPanel/MarkdownPanelController.cs
@@ -59,6 +59,8 @@ namespace NppMarkdownPanel
             settings = LoadSettingsFromIni();
             viewerInterface = MarkdownPreviewForm.InitViewer(settings, HandleWndProc);
             previewForm = (MarkdownPreviewForm)viewerInterface;
+            previewForm.SetCheckboxToggleHandler(ToggleCheckboxAtLine);
+            previewForm.SetRadioToggleHandler(ToggleRadioAtLine);
             renderTimer = new Timer();
             renderTimer.Interval = renderRefreshRateMilliSeconds;
             renderTimer.Tick += OnRenderTimerElapsed;
@@ -244,6 +246,108 @@ namespace NppMarkdownPanel
         private void ScrollToElementAtLineNo(int lineNo)
         {
             viewerInterface.ScrollToElementWithLineNo(lineNo);
+        }
+
+        private void ToggleCheckboxAtLine(int lineNo)
+        {
+            var gw = scintillaGatewayFactory();
+            string lineText = gw.GetLine(lineNo);
+
+            var idxEmpty = lineText.IndexOf("[ ]");
+            if (idxEmpty >= 0)
+            {
+                int pos = gw.PositionFromLine(lineNo) + idxEmpty + 1;
+                gw.SetSelection(pos, pos + 1);
+                gw.ReplaceSel("x");
+                RenderAfterToggle();
+                return;
+            }
+
+            var idxChecked = lineText.IndexOf("[x]", StringComparison.OrdinalIgnoreCase);
+            if (idxChecked >= 0)
+            {
+                int pos = gw.PositionFromLine(lineNo) + idxChecked + 1;
+                gw.SetSelection(pos, pos + 1);
+                gw.ReplaceSel(" ");
+                RenderAfterToggle();
+            }
+        }
+
+        private void RenderAfterToggle()
+        {
+            renderTimer.Stop();
+            RenderMarkdownDirect();
+        }
+
+        private void ToggleRadioAtLine(int lineNo)
+        {
+            var gw = scintillaGatewayFactory();
+            string lineText = gw.GetLine(lineNo);
+
+            var hasEmpty = lineText.IndexOf("( )") >= 0;
+            var idxChecked = lineText.IndexOf("(x)", StringComparison.OrdinalIgnoreCase);
+
+            if (hasEmpty)
+            {
+                int pos = gw.PositionFromLine(lineNo) + lineText.IndexOf("( )") + 1;
+                gw.SetSelection(pos, pos + 1);
+                gw.ReplaceSel("x");
+                UncheckRadioGroup(gw, lineNo);
+            }
+            else if (idxChecked >= 0)
+            {
+                int pos = gw.PositionFromLine(lineNo) + idxChecked + 1;
+                gw.SetSelection(pos, pos + 1);
+                gw.ReplaceSel(" ");
+            }
+
+            RenderAfterToggle();
+        }
+
+        private void UncheckRadioGroup(IScintillaGateway gw, int excludeLine)
+        {
+            int totalLines = gw.GetLineCount();
+            int startLine = excludeLine;
+            int endLine = excludeLine;
+
+            for (int i = excludeLine - 1; i >= 0; i--)
+            {
+                string text = gw.GetLine(i).TrimStart();
+                if (IsRadioLine(text))
+                    startLine = i;
+                else
+                    break;
+            }
+
+            for (int i = excludeLine + 1; i < totalLines; i++)
+            {
+                string text = gw.GetLine(i).TrimStart();
+                if (IsRadioLine(text))
+                    endLine = i;
+                else
+                    break;
+            }
+
+            for (int i = startLine; i <= endLine; i++)
+            {
+                if (i == excludeLine) continue;
+                string text = gw.GetLine(i);
+                int idx = text.IndexOf("(x)", StringComparison.OrdinalIgnoreCase);
+                if (idx >= 0)
+                {
+                    int pos = gw.PositionFromLine(i) + idx + 1;
+                    gw.SetSelection(pos, pos + 1);
+                    gw.ReplaceSel(" ");
+                }
+            }
+        }
+
+        private static bool IsRadioLine(string text)
+        {
+            if (!(text.StartsWith("- ") || text.StartsWith("* ") || text.StartsWith("+ ")))
+                return false;
+            int p = text.IndexOf('(');
+            return p >= 0 && p <= 3 && (text.Substring(p).StartsWith("( )") || text.Substring(p).StartsWith("(x)", StringComparison.OrdinalIgnoreCase));
         }
 
         public void InitCommandMenu()

--- a/NppMarkdownPanel/Resources/nppMdP.tests/Test-Checkbox.md
+++ b/NppMarkdownPanel/Resources/nppMdP.tests/Test-Checkbox.md
@@ -1,0 +1,57 @@
+# Checkbox Toggle Test
+
+## Test Tasks
+
+- [ ] Task 1: Setup project
+- [x] Task 2: Create repository
+- [ ] Task 3: Write documentation
+- [x] Task 4: Run tests
+- [ ] Task 5: Deploy to production
+
+## Mixed Content
+
+Here is a paragraph with some text before the list.
+
+- [ ] Download dependencies
+- [x] Configure environment
+- [ ] Build the application
+
+Some text after the list.
+
+## Nested Items (not supported for toggle)
+
+- [ ] Parent task
+  - [ ] Subtask A
+  - [x] Subtask B
+
+## Checkbox in Code Block (should not toggle)
+
+```
+- [ ] This is code, not a checkbox
+- [x] This should not be interactive
+```
+
+## Multiple Checkboxes on Same Line
+
+- [ ] First item [ ] should only toggle the first checkbox
+
+## Radio Toggle Test
+
+### Simple Radio Group
+
+- ( ) Option A
+- (x) Option B
+- ( ) Option C
+
+### Second Radio Group
+
+- ( ) Red
+- ( ) Green
+- (x) Blue
+
+### Mixed with Checkboxes
+
+- [ ] Checkbox item
+- ( ) Radio option 1
+- (x) Radio option 2
+- [x] Another checkbox

--- a/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
+++ b/NppMarkdownPanel/Webbrowser/IE11WebbrowserControl.cs
@@ -21,6 +21,8 @@ namespace NppMarkdownPanel.Webbrowser
         public Action<string> StatusTextChangedAction { get; set; }
         public Action RenderingDoneAction { get; set; }
         public Action AfterInitCompletedAction { get; set; }
+        public Action<int> CheckboxToggleAction { get; set; }
+        public Action<int> RadioToggleAction { get; set; }
 
         bool webViewInitialized = false;
 

--- a/PanelCommon/IWebbrowserControl.cs
+++ b/PanelCommon/IWebbrowserControl.cs
@@ -23,6 +23,8 @@ namespace PanelCommon
         Action<string> StatusTextChangedAction { get; set; }
         Action RenderingDoneAction { get; set; }
         Action AfterInitCompletedAction { get; set; }
+        Action<int> CheckboxToggleAction { get; set; }
+        Action<int> RadioToggleAction { get; set; }
 
         void Dispose();
 

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -23,6 +23,8 @@ namespace Webview2Viewer
         public Action<string> StatusTextChangedAction { get; set; }
         public Action RenderingDoneAction { get; set; }
         public Action AfterInitCompletedAction { get; set; }
+        public Action<int> CheckboxToggleAction { get; set; }
+        public Action<int> RadioToggleAction { get; set; }
 
         private string currentBody;
         private string currentStyle;
@@ -132,6 +134,16 @@ namespace Webview2Viewer
                     await webView.ExecuteScriptAsync(jsScript);
                 }));
 
+                ExecuteWebviewAction(new Action(async () =>
+                {
+                    await webView.ExecuteScriptAsync(checkboxToggleScript);
+                }));
+
+                ExecuteWebviewAction(new Action(async () =>
+                {
+                    await webView.ExecuteScriptAsync(radioToggleScript);
+                }));
+
                 blockScrollUpdates = false;
             }
 
@@ -154,6 +166,54 @@ namespace Webview2Viewer
             "var elementPosition = element.getBoundingClientRect().top;\n" +
             "var offsetPosition = elementPosition + window.pageYOffset - headerOffset;\n" +
             "window.scrollTo({{top: offsetPosition}});";
+
+        const string checkboxToggleScript = @"
+            var checkboxes = document.querySelectorAll('input[type=""checkbox""]');
+            for (var i = 0; i < checkboxes.length; i++) {
+                checkboxes[i].disabled = false;
+            }
+            if (!window.__checkboxToggleHandlerInstalled) {
+                window.__checkboxToggleHandlerInstalled = true;
+                document.addEventListener('click', function(e) {
+                    if (e.target.tagName === 'INPUT' && e.target.type === 'checkbox') {
+                        e.preventDefault();
+                        var line = e.target.closest('[data-line]');
+                        if (line) {
+                            window.chrome.webview.postMessage('checkboxToggle;' + line.getAttribute('data-line'));
+                        }
+                    }
+                }, true);
+            }";
+
+        const string radioToggleScript = @"
+            var lis = document.querySelectorAll('li[data-line]');
+            for (var i = 0; i < lis.length; i++) {
+                var li = lis[i];
+                var text = li.innerHTML;
+                if (/^\([ xX]\)\s/.test(text)) {
+                    li.innerHTML = text.replace(/^\([ xX]\)/, '<span class=""md-radio"">$&</span>');
+                }
+            }
+            if (!window.__radioToggleHandlerInstalled) {
+                window.__radioToggleHandlerInstalled = true;
+                document.addEventListener('click', function(e) {
+                    if (e.target.classList && e.target.classList.contains('md-radio')) {
+                        e.preventDefault();
+                        var line = e.target.closest('[data-line]');
+                        if (line) {
+                            var parentList = e.target.closest('ul, ol');
+                            if (parentList) {
+                                var radios = parentList.querySelectorAll('.md-radio');
+                                for (var j = 0; j < radios.length; j++) {
+                                    radios[j].textContent = '( )';
+                                }
+                            }
+                            e.target.textContent = '(x)';
+                            window.chrome.webview.postMessage('radioToggle;' + line.getAttribute('data-line'));
+                        }
+                    }
+                }, true);
+            }";
 
 
         public void ScrollToElementWithLineNo(int lineNo)
@@ -196,6 +256,8 @@ namespace Webview2Viewer
                     {
                         await webView.ExecuteScriptAsync("document.body.innerHTML = '" + HttpUtility.JavaScriptStringEncode(currentBody) + "'");
                         await webView.ExecuteScriptAsync("if(typeof mermaid!=='undefined'){mermaid.run();}");
+                        await webView.ExecuteScriptAsync(checkboxToggleScript);
+                        await webView.ExecuteScriptAsync(radioToggleScript);
                     }));
                 }
                 if (currentStyle != style)
@@ -298,7 +360,6 @@ namespace Webview2Viewer
         {
             string message = e.TryGetWebMessageAsString();
 
-            // Parse die JSON-Nachricht
             var splittedParams = message.Split(';');
             if (splittedParams.Length > 1)
             {
@@ -315,6 +376,34 @@ namespace Webview2Viewer
                         else
                         {
                             scrollYForFilename.Add(currentDocumentPath, scrolly);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                    }
+                }
+                else if (action == "checkboxToggle")
+                {
+                    try
+                    {
+                        int lineNo = int.Parse(splittedParams[1]);
+                        if (CheckboxToggleAction != null)
+                        {
+                            CheckboxToggleAction(lineNo);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                    }
+                }
+                else if (action == "radioToggle")
+                {
+                    try
+                    {
+                        int lineNo = int.Parse(splittedParams[1]);
+                        if (RadioToggleAction != null)
+                        {
+                            RadioToggleAction(lineNo);
                         }
                     }
                     catch (Exception ex)


### PR DESCRIPTION
Closes #7

Click rendered checkboxes and radio items in the preview pane to toggle them in the editor source.

### Checkbox toggle
- Native `<input type="checkbox">` elements enabled via JS
- On click, sends `checkboxToggle;<data-line>` to C# via `window.chrome.webview.postMessage`
- `ToggleCheckboxAtLine()` replaces `[ ]` ↔ `[x]` in editor via ScintillaGateway

### Radio toggle
- Uses `- ( )` / `- (x)` syntax (Markdig has no native radio support)
- JS wraps `( )` / `(x)` text in `<span class="md-radio">` for click handling
- Selecting one radio auto-deselects all other `(x)` in the same group
- Group = contiguous list items; separated by blank lines

### Other
- Debounce timer is bypassed after toggle for instant re-render
- Test file: `Test-Checkbox.md`