### PR TITLE
Add three-state toggle for Markdown Panel (docked → fullscreen → hidden)

### DIFF
--- a/NppMarkdownPanel/Entities/Settings.cs
+++ b/NppMarkdownPanel/Entities/Settings.cs
@@ -28,6 +28,7 @@ namespace NppMarkdownPanel.Entities
         public bool ShowToolbar { get; set; }
         public bool ShowStatusbar { get; set; }
         public bool AutoShowPanel { get; set; }
+        public bool EnableThreeStateToggle { get; set; }
 
         public string PreProcessorCommandFilename { get; set; }
         public string PreProcessorArguments { get; set; }

--- a/NppMarkdownPanel/Forms/SettingsForm.Designer.cs
+++ b/NppMarkdownPanel/Forms/SettingsForm.Designer.cs
@@ -61,6 +61,7 @@
             this.cbShowStatusbar = new System.Windows.Forms.CheckBox();
             this.cbAllowAllExtensions = new System.Windows.Forms.CheckBox();
             this.cbFilesWithNoExt = new System.Windows.Forms.CheckBox();
+            this.cbEnableThreeStateToggle = new System.Windows.Forms.CheckBox();
             this.panel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar1)).BeginInit();
@@ -101,7 +102,7 @@
             // btnSave
             // 
             this.btnSave.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnSave.Location = new System.Drawing.Point(468, 568);
+            this.btnSave.Location = new System.Drawing.Point(468, 583);
             this.btnSave.Name = "btnSave";
             this.btnSave.Size = new System.Drawing.Size(105, 36);
             this.btnSave.TabIndex = 20;
@@ -113,7 +114,7 @@
             // 
             this.btnCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(579, 568);
+            this.btnCancel.Location = new System.Drawing.Point(579, 583);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(105, 36);
             this.btnCancel.TabIndex = 21;
@@ -244,7 +245,7 @@
             this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.sblInvalidHtmlPath});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 616);
+            this.statusStrip1.Location = new System.Drawing.Point(0, 631);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Size = new System.Drawing.Size(696, 22);
             this.statusStrip1.TabIndex = 16;
@@ -408,13 +409,25 @@
             this.cbFilesWithNoExt.UseVisualStyleBackColor = true;
             this.cbFilesWithNoExt.CheckedChanged += new System.EventHandler(this.cbFilesWithNoExt_CheckedChanged);
             // 
+            // cbEnableThreeStateToggle
+            // 
+            this.cbEnableThreeStateToggle.AutoSize = true;
+            this.cbEnableThreeStateToggle.Location = new System.Drawing.Point(170, 556);
+            this.cbEnableThreeStateToggle.Name = "cbEnableThreeStateToggle";
+            this.cbEnableThreeStateToggle.Size = new System.Drawing.Size(317, 21);
+            this.cbEnableThreeStateToggle.TabIndex = 28;
+            this.cbEnableThreeStateToggle.Text = "Enable three-state toggle (docked → fullscreen → hidden)";
+            this.cbEnableThreeStateToggle.UseVisualStyleBackColor = true;
+            this.cbEnableThreeStateToggle.CheckedChanged += new System.EventHandler(this.cbEnableThreeStateToggle_CheckedChanged);
+            // 
             // SettingsForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(696, 638);
+            this.ClientSize = new System.Drawing.Size(696, 653);
             this.Controls.Add(this.cbFilesWithNoExt);
+            this.Controls.Add(this.cbEnableThreeStateToggle);
             this.Controls.Add(this.cbAllowAllExtensions);
             this.Controls.Add(this.comboRenderingEngine);
             this.Controls.Add(this.label6);
@@ -494,5 +507,6 @@
         private System.Windows.Forms.CheckBox cbShowStatusbar;
         private System.Windows.Forms.CheckBox cbAllowAllExtensions;
         private System.Windows.Forms.CheckBox cbFilesWithNoExt;
+        private System.Windows.Forms.CheckBox cbEnableThreeStateToggle;
     }
 }

--- a/NppMarkdownPanel/Forms/SettingsForm.cs
+++ b/NppMarkdownPanel/Forms/SettingsForm.cs
@@ -16,6 +16,7 @@ namespace NppMarkdownPanel.Forms
         public bool SupportFilesWithNoExt { get; set; }
         public bool AutoShowPanel { get; set; }
         public bool ShowStatusbar { get; set; }
+        public bool EnableThreeStateToggle { get; set; }
         public string RenderingEngine { get; set; }
 
 
@@ -32,6 +33,7 @@ namespace NppMarkdownPanel.Forms
             RenderingEngine = settings.RenderingEngine;
             AllowAllExtensions = settings.AllowAllExtensions;
             SupportFilesWithNoExt = settings.SupportFilesWithNoExt;
+            EnableThreeStateToggle = settings.EnableThreeStateToggle;
 
             InitializeComponent();
 
@@ -46,6 +48,7 @@ namespace NppMarkdownPanel.Forms
             cbShowStatusbar.Checked = ShowStatusbar;
             cbAllowAllExtensions.Checked = AllowAllExtensions;
             cbFilesWithNoExt.Checked = SupportFilesWithNoExt;
+            cbEnableThreeStateToggle.Checked = EnableThreeStateToggle;
 
             if (settings.IsRenderingEngineIE11())
             {
@@ -238,6 +241,11 @@ namespace NppMarkdownPanel.Forms
         private void cbFilesWithNoExt_CheckedChanged(object sender, EventArgs e)
         {
             SupportFilesWithNoExt = cbFilesWithNoExt.Checked;
+        }
+
+        private void cbEnableThreeStateToggle_CheckedChanged(object sender, EventArgs e)
+        {
+            EnableThreeStateToggle = cbEnableThreeStateToggle.Checked;
         }
     }
 }

--- a/NppMarkdownPanel/MarkdownPanelController.cs
+++ b/NppMarkdownPanel/MarkdownPanelController.cs
@@ -29,7 +29,9 @@ namespace NppMarkdownPanel
         private const int inputUpdateThresholdMiliseconds = 400;
         private int lastTickCount = 0;
 
-        private bool isPanelVisible;
+        private enum PanelState { Hidden, Docked, FullScreen }
+        private PanelState _panelState;
+        private bool isPanelVisible => _panelState != PanelState.Hidden;
 
         private readonly Func<IScintillaGateway> scintillaGatewayFactory;
         private readonly INotepadPPGateway notepadPPGateway;
@@ -48,6 +50,8 @@ namespace NppMarkdownPanel
         private bool _disposedValue;
         IntPtr _ptrNppTbData;
         private Icon _icon;
+        private IntPtr _fullScreenSplitterHandle;
+        private double _savedWidthRatio;
 
         public MarkdownPanelController()
         {
@@ -369,6 +373,33 @@ namespace NppMarkdownPanel
 
         private void TogglePanelVisible()
         {
+            switch (_panelState)
+            {
+                case PanelState.Hidden:
+                    ShowDocked();
+                    _panelState = PanelState.Docked;
+                    break;
+                case PanelState.Docked:
+                    GoFullscreen();
+                    _panelState = PanelState.FullScreen;
+                    break;
+                case PanelState.FullScreen:
+                    RestoreFromFullscreen();
+                    _panelState = PanelState.Hidden;
+                    break;
+            }
+
+            if (isPanelVisible)
+            {
+                var currentFilePath = notepadPPGateway.GetCurrentFilePath();
+                viewerInterface.SetMarkdownFilePath(currentFilePath);
+                viewerInterface.UpdateSettings(settings);
+                RenderMarkdownDirect(false);
+            }
+        }
+
+        private void ShowDocked()
+        {
             if (!initDialog)
             {
                 NppTbData _nppTbData = new NppTbData();
@@ -387,15 +418,122 @@ namespace NppMarkdownPanel
             }
             else
             {
-                Win32.SendMessage(PluginBase.nppData._nppHandle, !isPanelVisible ? (uint)NppMsg.NPPM_DMMSHOW : (uint)NppMsg.NPPM_DMMHIDE, 0, viewerInterface.Handle);
+                Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_DMMSHOW, 0, viewerInterface.Handle);
             }
-            isPanelVisible = !isPanelVisible;
-            if (isPanelVisible)
+        }
+
+        private void GoFullscreen()
+        {
+            var containerHandle = Win32.GetParent(viewerInterface.Handle);
+            var nppHandle = PluginBase.nppData._nppHandle;
+
+            _fullScreenSplitterHandle = FindRightSplitter(nppHandle, containerHandle);
+
+            var dockMgrHandle = Win32.FindWindowEx(nppHandle, IntPtr.Zero, Win32.DOCKING_MANAGER_CLASS, null);
+
+            if (dockMgrHandle != IntPtr.Zero && _fullScreenSplitterHandle != IntPtr.Zero)
             {
-                var currentFilePath = notepadPPGateway.GetCurrentFilePath();
-                viewerInterface.SetMarkdownFilePath(currentFilePath);
-                viewerInterface.UpdateSettings(settings);
-                RenderMarkdownDirect(false);
+                Win32.GetClientRect(nppHandle, out RECT nppClient);
+                Win32.GetWindowRect(containerHandle, out RECT containerScreenRect);
+
+                var clientOrigin = new Point(0, 0);
+                Win32.ClientToScreen(nppHandle, ref clientOrigin);
+
+                int currentWidth = containerScreenRect.Right - containerScreenRect.Left;
+                _savedWidthRatio = (double)currentWidth / nppClient.Right;
+                int targetOffset = nppClient.Right - currentWidth - 4;
+
+                Win32.SendMessage(dockMgrHandle, (uint)DockMgrMsg.DMM_MOVE_SPLITTER, targetOffset, _fullScreenSplitterHandle);
+            }
+        }
+
+        private IntPtr FindRightSplitter(IntPtr nppHandle, IntPtr containerHandle)
+        {
+            Win32.GetWindowRect(containerHandle, out RECT containerScreenRect);
+
+            IntPtr hwnd = IntPtr.Zero;
+            while ((hwnd = Win32.FindWindowEx(nppHandle, hwnd, Win32.VERT_SPLITTER_CLASS, null)) != IntPtr.Zero)
+            {
+                Win32.GetWindowRect(hwnd, out RECT splitterRect);
+                if (splitterRect.Right >= containerScreenRect.Left - 10 && splitterRect.Right <= containerScreenRect.Left + 5)
+                    return hwnd;
+            }
+            return IntPtr.Zero;
+        }
+
+        private void RestoreFromFullscreen()
+        {
+            var nppHandle = PluginBase.nppData._nppHandle;
+            var dockMgrHandle = Win32.FindWindowEx(nppHandle, IntPtr.Zero, Win32.DOCKING_MANAGER_CLASS, null);
+
+            if (dockMgrHandle != IntPtr.Zero && _fullScreenSplitterHandle != IntPtr.Zero && _savedWidthRatio > 0)
+            {
+                Win32.GetClientRect(nppHandle, out RECT nppClient);
+                var containerHandle = Win32.GetParent(viewerInterface.Handle);
+                Win32.GetWindowRect(containerHandle, out RECT containerScreenRect);
+
+                var clientOrigin = new Point(0, 0);
+                Win32.ClientToScreen(nppHandle, ref clientOrigin);
+
+                int currentWidth = containerScreenRect.Right - containerScreenRect.Left;
+                int targetWidth = (int)(nppClient.Right * _savedWidthRatio);
+                int restoreOffset = targetWidth - currentWidth;
+
+                Win32.SendMessage(dockMgrHandle, (uint)DockMgrMsg.DMM_MOVE_SPLITTER, restoreOffset, _fullScreenSplitterHandle);
+            }
+            _savedWidthRatio = 0;
+            _fullScreenSplitterHandle = IntPtr.Zero;
+
+            Win32.SendMessage(nppHandle, (uint)NppMsg.NPPM_DMMHIDE, 0, viewerInterface.Handle);
+        }
+
+        private void ToolWindowCloseAction()
+        {
+            if (_panelState == PanelState.FullScreen)
+            {
+                var nppHandle = PluginBase.nppData._nppHandle;
+                var dockMgrHandle = Win32.FindWindowEx(nppHandle, IntPtr.Zero, Win32.DOCKING_MANAGER_CLASS, null);
+
+                if (dockMgrHandle != IntPtr.Zero && _fullScreenSplitterHandle != IntPtr.Zero && _savedWidthRatio > 0)
+                {
+                    Win32.GetClientRect(nppHandle, out RECT nppClient);
+                    var containerHandle = Win32.GetParent(viewerInterface.Handle);
+                    Win32.GetWindowRect(containerHandle, out RECT containerScreenRect);
+
+                    var clientOrigin = new Point(0, 0);
+                    Win32.ClientToScreen(nppHandle, ref clientOrigin);
+
+                    int currentWidth = containerScreenRect.Right - containerScreenRect.Left;
+                    int targetWidth = (int)(nppClient.Right * _savedWidthRatio);
+                    int restoreOffset = targetWidth - currentWidth;
+
+                    Win32.SendMessage(dockMgrHandle, (uint)DockMgrMsg.DMM_MOVE_SPLITTER, restoreOffset, _fullScreenSplitterHandle);
+                }
+                _savedWidthRatio = 0;
+                _fullScreenSplitterHandle = IntPtr.Zero;
+            }
+            _panelState = PanelState.Hidden;
+        }
+
+        private void AutoShowOrHidePanel(string currentFilePath)
+        {
+            if (nppReady && settings.AutoShowPanel)
+            {
+                if (_panelState == PanelState.FullScreen)
+                {
+                    if (!viewerInterface.IsValidFileExtension(currentFilePath))
+                    {
+                        RestoreFromFullscreen();
+                        _panelState = PanelState.Hidden;
+                    }
+                    return;
+                }
+
+                if ((!isPanelVisible && viewerInterface.IsValidFileExtension(currentFilePath)) ||
+                    (isPanelVisible && !viewerInterface.IsValidFileExtension(currentFilePath)))
+                {
+                    TogglePanelVisible();
+                }
             }
         }
 
@@ -415,33 +553,11 @@ namespace NppMarkdownPanel
             }
         }
 
-        /// <summary>
-        /// Actions to do after the tool window was closed
-        /// </summary>
-        private void ToolWindowCloseAction()
-        {
-            TogglePanelVisible();
-        }
-
         private bool IsDarkModeEnabled()
         {
             // NPPM_ISDARKMODEENABLED (NPPMSG + 107)
             IntPtr ret = Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)(Constants.NPPMSG + 107), Unused, Unused);
             return ret.ToInt32() == 1;
-        }
-
-
-        private void AutoShowOrHidePanel(string currentFilePath)
-        {
-            if (nppReady && settings.AutoShowPanel)
-            {
-                // automatically show panel for supported file types
-                if ((!isPanelVisible && viewerInterface.IsValidFileExtension(currentFilePath)) ||
-                    (isPanelVisible && !viewerInterface.IsValidFileExtension(currentFilePath)))
-                {
-                    TogglePanelVisible();
-                }
-            }
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/NppMarkdownPanel/MarkdownPanelController.cs
+++ b/NppMarkdownPanel/MarkdownPanelController.cs
@@ -100,6 +100,7 @@ namespace NppMarkdownPanel
             settings.AllowAllExtensions = PluginUtils.ReadIniBool("Options", "AllowAllExtensions", iniFilePath);
             settings.IsDarkModeEnabled = IsDarkModeEnabled();
             settings.AutoShowPanel = PluginUtils.ReadIniBool("Options", "AutoShowPanel", iniFilePath);
+            settings.EnableThreeStateToggle = PluginUtils.ReadIniBool("Options", "EnableThreeStateToggle", iniFilePath);
             settings.RenderingEngine = Win32.ReadIniValue("Options", "RenderingEngine", iniFilePath, Settings.RENDERING_ENGINE_WEBVIEW2_EDGE);
             return settings;
         }
@@ -280,6 +281,7 @@ namespace NppMarkdownPanel
                 settings.AllowAllExtensions = settingsForm.AllowAllExtensions;
                 settings.ShowStatusbar = settingsForm.ShowStatusbar;
                 settings.AutoShowPanel = settingsForm.AutoShowPanel;
+                settings.EnableThreeStateToggle = settingsForm.EnableThreeStateToggle;
                 settings.RenderingEngine = settingsForm.RenderingEngine;
 
                 settings.IsDarkModeEnabled = IsDarkModeEnabled();
@@ -360,6 +362,7 @@ namespace NppMarkdownPanel
             Win32.WriteIniValue("Options", "SupportedFileExt", settings.SupportedFileExt, iniFilePath);
             Win32.WriteIniValue("Options", "SupportFilesWithNoExt", settings.SupportFilesWithNoExt.ToString(), iniFilePath);
             Win32.WriteIniValue("Options", "AutoShowPanel", settings.AutoShowPanel.ToString(), iniFilePath);
+            Win32.WriteIniValue("Options", "EnableThreeStateToggle", settings.EnableThreeStateToggle.ToString(), iniFilePath);
             Win32.WriteIniValue("Options", "AllowAllExtensions", settings.AllowAllExtensions.ToString(), iniFilePath);
             Win32.WriteIniValue("Options", "RenderingEngine", settings.RenderingEngine, iniFilePath);
         }
@@ -373,20 +376,41 @@ namespace NppMarkdownPanel
 
         private void TogglePanelVisible()
         {
-            switch (_panelState)
+            if (settings.EnableThreeStateToggle)
             {
-                case PanelState.Hidden:
-                    ShowDocked();
-                    _panelState = PanelState.Docked;
-                    break;
-                case PanelState.Docked:
-                    GoFullscreen();
-                    _panelState = PanelState.FullScreen;
-                    break;
-                case PanelState.FullScreen:
+                switch (_panelState)
+                {
+                    case PanelState.Hidden:
+                        ShowDocked();
+                        _panelState = PanelState.Docked;
+                        break;
+                    case PanelState.Docked:
+                        GoFullscreen();
+                        _panelState = PanelState.FullScreen;
+                        break;
+                    case PanelState.FullScreen:
+                        RestoreFromFullscreen();
+                        _panelState = PanelState.Hidden;
+                        break;
+                }
+            }
+            else
+            {
+                if (_panelState == PanelState.FullScreen)
+                {
                     RestoreFromFullscreen();
                     _panelState = PanelState.Hidden;
-                    break;
+                }
+                else if (_panelState == PanelState.Hidden)
+                {
+                    ShowDocked();
+                    _panelState = PanelState.Docked;
+                }
+                else
+                {
+                    Win32.SendMessage(PluginBase.nppData._nppHandle, (uint)NppMsg.NPPM_DMMHIDE, 0, viewerInterface.Handle);
+                    _panelState = PanelState.Hidden;
+                }
             }
 
             if (isPanelVisible)

--- a/NppMarkdownPanel/PluginInfrastructure/Win32.cs
+++ b/NppMarkdownPanel/PluginInfrastructure/Win32.cs
@@ -394,5 +394,20 @@ namespace Kbg.NppPluginNET.PluginInfrastructure
         {
             WritePrivateProfileString(section, key, value, iniFileName);
         }
+
+        [DllImport("user32")]
+        public static extern bool GetClientRect(IntPtr hWnd, out RECT lpRect);
+
+        [DllImport("user32")]
+        public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+        [DllImport("user32")]
+        public static extern IntPtr GetParent(IntPtr hWnd);
+
+        [DllImport("user32")]
+        public static extern IntPtr FindWindowEx(IntPtr hWndParent, IntPtr hWndChildAfter, string lpszClass, string lpszWindow);
+
+        public const string DOCKING_MANAGER_CLASS = "dockingManager";
+        public const string VERT_SPLITTER_CLASS = "wedockspliter";
     }
 }


### PR DESCRIPTION
Implements a three-state cycle for the "Toggle Markdown Panel" button:

| Click | Transition | Result |
|-------|-----------|--------|
| 1st | Hidden → Docked | Panel opens docked on the right (existing behavior) |
| 2nd | Docked → Fullscreen | Panel expands to nearly full width, covering the editor |
| 3rd | Fullscreen → Hidden | Panel closes, editor layout restored |

## Implementation

- Replaced `isPanelVisible` bool with `PanelState` enum (`Hidden`, `Docked`, `FullScreen`)
- Fullscreen expansion uses `DMM_MOVE_SPLITTER` message to the Notepad++ DockingManager
- Original panel width saved as ratio of client area, enabling correct restoration after resize
- `ToolWindowCloseAction` and `AutoShowOrHidePanel` updated for the new state model

Closes #138