### PR TITLE
Markdig update

### DIFF
--- a/MarkdigWrapper/App.config
+++ b/MarkdigWrapper/App.config
@@ -3,12 +3,4 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
 </configuration>

--- a/MarkdigWrapper/Markdig/SyntaxHighlighting/LanguageTypeAdapter.cs
+++ b/MarkdigWrapper/Markdig/SyntaxHighlighting/LanguageTypeAdapter.cs
@@ -4,7 +4,6 @@ using ColorCode;
 
 namespace Markdig.SyntaxHighlighting {
     public class LanguageTypeAdapter {
-        public const string LANGUAGE_KEY_MERMAID = "mermaid";
         private readonly Dictionary<string, ILanguage> languageMap = new Dictionary<string, ILanguage> {
             {"csharp", Languages.CSharp},
             {"cplusplus", Languages.Cpp}

--- a/MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -41,12 +41,11 @@ namespace Markdig.SyntaxHighlighting
                 return;
             }
 
-            if (string.Equals(languageMoniker, LanguageTypeAdapter.LANGUAGE_KEY_MERMAID, StringComparison.OrdinalIgnoreCase))
+            if (_underlyingRenderer != null
+                && ((_underlyingRenderer.BlockMapping != null && _underlyingRenderer.BlockMapping.ContainsKey(languageMoniker))
+                    || (_underlyingRenderer.BlocksAsDiv != null && _underlyingRenderer.BlocksAsDiv.Contains(languageMoniker))))
             {
-                var mermaidCode = GetCode(obj, out _);
-                renderer.Write("<pre class=\"mermaid\">");
-                renderer.WriteEscape(mermaidCode);
-                renderer.WriteLine("</pre>");
+                _underlyingRenderer.Write(renderer, obj);
                 return;
             }
 
@@ -75,7 +74,7 @@ namespace Markdig.SyntaxHighlighting
             var language = languageTypeAdapter.Parse(languageMoniker, firstLine);
 
             if (language?.Id == null)
-            { // TODO: handle unrecognised language formats, e.g. when using mermaid diagrams
+            { // TODO: handle unrecognised language formats
                 return code;
             }
 

--- a/MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
+++ b/MarkdigWrapper/Markdig/SyntaxHighlighting/SyntaxHighlightingCodeBlockRenderer.cs
@@ -74,7 +74,7 @@ namespace Markdig.SyntaxHighlighting
             var language = languageTypeAdapter.Parse(languageMoniker, firstLine);
 
             if (language?.Id == null)
-            { // TODO: handle unrecognised language formats
+            { // TODO: handle unrecognised language formats, e.g. when using mermaid diagrams
                 return code;
             }
 

--- a/MarkdigWrapper/MarkdigWrapper.csproj
+++ b/MarkdigWrapper/MarkdigWrapper.csproj
@@ -57,23 +57,16 @@
     <Reference Include="ColorCode, Version=1.0.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\ColorCode.Portable.1.0.3\lib\portable45-net45+win8+wp8+wpa81\ColorCode.dll</HintPath>
     </Reference>
-    <Reference Include="Markdig, Version=0.41.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Markdig.0.41.3\lib\net462\Markdig.dll</HintPath>
+    <Reference Include="Markdig">
+      <HintPath>..\packages\Markdig.1.3.2\lib\net462\Markdig.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Buffers.4.6.0\lib\net462\System.Buffers.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Memory, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Memory.4.6.0\lib\net462\System.Memory.dll</HintPath>
+    <Reference Include="System.Memory">
+      <HintPath>..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System.Numerics" />
-    <Reference Include="System.Numerics.Vectors, Version=4.1.5.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Numerics.Vectors.4.6.0\lib\net462\System.Numerics.Vectors.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.0\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PanelCommon\PanelCommon.csproj">

--- a/MarkdigWrapper/packages.config
+++ b/MarkdigWrapper/packages.config
@@ -1,10 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ColorCode.Portable" version="1.0.3" targetFramework="net452" />
-  <package id="Markdig" version="0.41.3" targetFramework="net472" />
-  <package id="System.Buffers" version="4.6.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.6.0" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.6.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.0" targetFramework="net472" />
+  <package id="Markdig" version="1.3.2" targetFramework="net472" />
+  <package id="System.Memory" version="4.6.3" targetFramework="net472" />
   <package id="UnmanagedExports.Repack.Upgrade" version="1.2.1" targetFramework="net472" />
 </packages>

--- a/NppMarkdownPanel/Forms/AboutForm.cs
+++ b/NppMarkdownPanel/Forms/AboutForm.cs
@@ -16,7 +16,7 @@ namespace NppMarkdownPanel.Forms
 
         private const string AboutDialogText =
                 "NppMarkdownPanel for Notepad++\r\n\r\nVersion {0}\r\n\r\nCreated by Mohzy 2019-2026\r\n\r\nGithub: https://github.com/mohzy83/NppMarkdownPanel\r\n\r\nUsed Libs and Resources:\r\n\r\n" +
-                "Markdig 0.41.3 by xoofx - https://github.com/lunet-io/markdig\r\n\r\n" +
+                "Markdig 1.3.2 by xoofx - https://github.com/xoofx/markdig\r\n\r\n" +
                 "NotepadPlusPlusPluginPack.Net 0.95.00 by kbilsted - https://github.com/kbilsted/NotepadPlusPlusPluginPack.Net\t\r\n\r\n" +
                 "WebView2 Edge 1.0.3650.58 by Microsoft - https://developer.microsoft.com/de-de/microsoft-edge/webview2?form=MA13LH\r\n\r\n" +
                 "ColorCode (Portable) 1.0.3 by Bashir Souid and  Richard Slater\r\nhttps://github.com/RichardSlater/ColorCodePortable\r\n\r\n" +


### PR DESCRIPTION
## Upgrade Markdig 0.41.3 → 1.3.2 + Mermaid DiagramExtension Refactor

### Summary
Upgraded the Markdig library from 0.41.3 to 1.3.2 and simplified mermaid/nomnoml support by leveraging Markdig 1.3.2's built-in `DiagramExtension`.

### Changes

**Dependencies**
- `Markdig` 0.41.3 → 1.3.2
- `System.Memory` 4.6.0 → 4.6.3
- Removed unnecessary transitive packages (`System.Buffers`, `System.Numerics.Vectors`, `System.Runtime.CompilerServices.Unsafe`)

**Mermaid / Diagrams**
- Markdig 1.3.2's `DiagramExtension` (included in `UseAdvancedExtensions()`) sets `CodeBlockRenderer.BlockMapping["mermaid"] = "pre"`, producing `<pre class="mermaid">` markup for mermaid blocks
- Removed custom mermaid rendering code from `SyntaxHighlightingCodeBlockRenderer`
- Removed `LANGUAGE_KEY_MERMAID` constant from `LanguageTypeAdapter`
- `SyntaxHighlightingCodeBlockRenderer` now delegates to `_underlyingRenderer` for any language present in `BlockMapping` or `BlocksAsDiv`, ensuring diagram blocks receive the correct markup

**Cleanup**
- Removed stale assembly binding redirect from `App.config` (auto-generated by MSBuild)
- Updated Markdig version and repo URL in `AboutForm.cs`

### Testing
- Release x86 + x64 build: passed (0 errors, 4 pre-existing warnings in WebView2)
- Mermaid diagrams continue to render via client-side `mermaid.js`