### PR TITLE
Fix XSS vulnerability in Markdown rendering via HTML sanitization

### DIFF
--- a/MarkdigWrapper/MarkdigMarkdownGenerator.cs
+++ b/MarkdigWrapper/MarkdigMarkdownGenerator.cs
@@ -11,14 +11,18 @@ using Markdig.Renderers.Html;
 using Markdig.Syntax;
 using Markdig.SyntaxHighlighting;
 using MarkdigWrapper.Markdig.YamlFrontMatter;
+using Ganss.Xss;
 
 namespace MarkdigWrapper
 {
     public class MarkdigMarkdownGenerator
     {
+        private static readonly HtmlSanitizer htmlSanitizer = new HtmlSanitizer();
 
         public MarkdigMarkdownGenerator()
         {
+            htmlSanitizer.AllowedAttributes.Add("data-line");
+            htmlSanitizer.AllowedAttributes.Add("class");
         }
 
         public string ConvertToHtml(string markDownText, string filepath, bool supportEscapeCharsInUris)
@@ -77,6 +81,7 @@ namespace MarkdigWrapper
 
             if (supportEscapeCharsInUris) result = UnescapeImageUris(result);
             if (supportEscapeCharsInUris) result = UnescapeAnchorUris(result);
+            result = htmlSanitizer.Sanitize(result);
             return result;
         }
 

--- a/MarkdigWrapper/MarkdigWrapper.csproj
+++ b/MarkdigWrapper/MarkdigWrapper.csproj
@@ -79,6 +79,26 @@
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.6.1.2\lib\net462\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="HtmlSanitizer">
+      <HintPath>..\packages\HtmlSanitizer.9.0.892\lib\net47\HtmlSanitizer.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="AngleSharp">
+      <HintPath>..\packages\AngleSharp.0.17.1\lib\net472\AngleSharp.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="AngleSharp.Css">
+      <HintPath>..\packages\AngleSharp.Css.0.17.0\lib\netstandard2.0\AngleSharp.Css.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Collections.Immutable">
+      <HintPath>..\packages\System.Collections.Immutable.10.0.0\lib\net462\System.Collections.Immutable.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.6.0.0\lib\net462\System.Text.Encoding.CodePages.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PanelCommon\PanelCommon.csproj">

--- a/MarkdigWrapper/packages.config
+++ b/MarkdigWrapper/packages.config
@@ -7,4 +7,9 @@
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net472" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net472" />
   <package id="UnmanagedExports.Repack.Upgrade" version="1.2.1" targetFramework="net472" />
+  <package id="HtmlSanitizer" version="9.0.892" targetFramework="net472" />
+  <package id="AngleSharp" version="0.17.1" targetFramework="net472" />
+  <package id="AngleSharp.Css" version="0.17.0" targetFramework="net472" />
+  <package id="System.Collections.Immutable" version="10.0.0" targetFramework="net472" />
+  <package id="System.Text.Encoding.CodePages" version="6.0.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
Added [HtmlSanitizer](https://github.com/mganss/HtmlSanitizer) (v9.0.892) to sanitize HTML output after Markdig rendering, before browser display.

### Blocked

| Category | Examples |
|---|---|
| Script tags | `<script>`, `<script src="...">` |
| Event handlers | `onclick`, `onerror`, `onload`, `onmouseover` |
| Dangerous URLs | `javascript:`, `data:`, `vbscript:` |
| Embedded content | `<iframe>`, `<embed>`, `<object>`, `<applet>` |
| Style/script elements | `<style>`, `<link>`, `<meta>` |
| Form elements | `<form>`, `<input>`, `<button>`, `<textarea>` |

### Allowed

| Category | Examples |
|---|---|
| Headings | `h1`–`h6` |
| Text structure | `p`, `pre`, `code`, `blockquote`, `hr`, `br` |
| Inline formatting | `em`, `strong`, `del`, `ins`, `sub`, `sup`, `mark`, `kbd` |
| Lists & tables | `ul`, `ol`, `li`, `dl`, `dt`, `dd`, `table`, `thead`, `tbody`, `tr`, `th`, `td` |
| Semantic | `details`, `summary`, `figure`, `figcaption`, `article`, `section`, `nav` |
| Media & links | `<img>` (safe attrs), `<a href="http(s)://...">` |
| Containers | `span`, `div` |
| Attributes | `id`, `class`, `data-line`, `title`, `style` (safe CSS only) |

### New NuGet dependencies

| Package | Version |
|---|---|
| HtmlSanitizer | 9.0.892 |
| AngleSharp | 0.17.1 |
| AngleSharp.Css | 0.17.0 |
| System.Collections.Immutable | 10.0.0 |
| System.Text.Encoding.CodePages | 6.0.0 |

Closes #180 