### PR TITLE
Allow file:// scheme and id attribute in HTML sanitizer

### DIFF
--- a/MarkdigWrapper/MarkdigMarkdownGenerator.cs
+++ b/MarkdigWrapper/MarkdigMarkdownGenerator.cs
@@ -23,6 +23,8 @@ namespace MarkdigWrapper
         {
             htmlSanitizer.AllowedAttributes.Add("data-line");
             htmlSanitizer.AllowedAttributes.Add("class");
+            htmlSanitizer.AllowedAttributes.Add("id");
+            htmlSanitizer.AllowedSchemes.Add("file");
         }
 
         public string ConvertToHtml(string markDownText, string filepath, bool supportEscapeCharsInUris)


### PR DESCRIPTION
HtmlSanitizer was blocking two things needed by the Markdown preview:
- file:/// URLs (local images and file links) — added to AllowedSchemes
- id attribute (anchor/fragment targets on headers) — added to AllowedAttributes

Without id, Markdig-generated anchors like `<h1 id="header-one">` were stripped, breaking all in-page `#fragment` navigation.