### PR TITLE
Add optional WebView2 Offline-mode with local Mermaid support

### DIFF
--- a/NppMarkdownPanel/Entities/Settings.cs
+++ b/NppMarkdownPanel/Entities/Settings.cs
@@ -30,6 +30,8 @@ namespace NppMarkdownPanel.Entities
         public bool AutoShowPanel { get; set; }
         public bool EnableThreeStateToggle { get; set; }
         public bool ShowOutline { get; set; }
+        public bool OfflineMode { get; set; }
+        public string OfflineMermaidScriptFileName { get; set; }
 
         public string PreProcessorCommandFilename { get; set; }
         public string PreProcessorArguments { get; set; }

--- a/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
+++ b/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
@@ -16,17 +16,29 @@ namespace NppMarkdownPanel.Forms
 {
     public partial class MarkdownPreviewForm : DockingFormBase, IViewerInterface
     {
+        private const string MermaidScriptPlaceholder =
+            "<!-- MERMAID_SCRIPT_PLACEHOLDER -->";
+        private const string OfflineContentSecurityPolicyPlaceholder =
+            "<!-- OFFLINE_CSP_PLACEHOLDER -->";
+
+        private const string MermaidCdnScriptTag =
+            @"<script src=""https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"" onerror=""this.remove();""></script>";
+
+        private const string OfflineContentSecurityPolicyMetaTag =
+            @"<meta http-equiv=""Content-Security-Policy"" content=""default-src 'none'; img-src data: file: http://markdownpanel-virtualhost; media-src file: http://markdownpanel-virtualhost; style-src 'unsafe-inline' file: http://markdownpanel-virtualhost; script-src 'unsafe-inline' file: https://markdownpanel-offline.local; font-src data: file: http://markdownpanel-virtualhost; connect-src 'none'; frame-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'""></meta>";
+
         const string DEFAULT_HTML_BASE =
          @"<!DOCTYPE html>
             <html>
                 <head>                    
                     <meta http-equiv=""X-UA-Compatible"" content=""IE=edge""></meta>
                     <meta http-equiv=""content-type"" content=""text/html; charset=utf-8""></meta>
+                    <!-- OFFLINE_CSP_PLACEHOLDER -->
                     <title>{0}</title>
                     <style type=""text/css"">
                     {1}
                     </style>
-                    <script src=""https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"" onerror=""this.remove();""></script>
+                    <!-- MERMAID_SCRIPT_PLACEHOLDER -->
                     <script>
                     if(typeof mermaid!=='undefined'){{mermaid.initialize({{ startOnLoad: false }});}}
                     </script>
@@ -46,11 +58,12 @@ namespace NppMarkdownPanel.Forms
                 <head>                    
                     <meta http-equiv=""X-UA-Compatible"" content=""IE=edge""></meta>
                     <meta http-equiv=""content-type"" content=""text/html; charset=utf-8""></meta>
+                    <!-- OFFLINE_CSP_PLACEHOLDER -->
                     <title>{0}</title>
                     <style type=""text/css"">
                     {1}
                     </style>
-                    <script src=""https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"" onerror=""this.remove();""></script>
+                    <!-- MERMAID_SCRIPT_PLACEHOLDER -->
                     <script>
                     if(typeof mermaid!=='undefined'){{mermaid.initialize({{ startOnLoad: false }});}}
                     </script>
@@ -143,6 +156,8 @@ OUTLINE_SCRIPT_PLACEHOLDER
         private IWebbrowserControl webbrowserControl;
         private IWebbrowserControl webview1Instance;
         private IWebbrowserControl webview2Instance;
+        private bool? webview2OfflineMode;
+        private string webview2OfflineMermaidScriptFileName;
         private bool cleanupStarted;
         private Action<int> checkboxToggleHandler;
         private Action<int> radioToggleHandler;
@@ -165,8 +180,30 @@ OUTLINE_SCRIPT_PLACEHOLDER
             }
         }
 
-        public void UpdateSettings(Settings newSettings, Action<string> openLocalFileInNppAction)
+        public void UpdateSettings(
+            Settings newSettings,
+            Action<string> openLocalFileInNppAction)
         {
+            bool edgeSettingsChanged =
+                webview2Instance != null &&
+                (webview2OfflineMode != newSettings.OfflineMode ||
+                 !String.Equals(
+                     webview2OfflineMermaidScriptFileName,
+                     newSettings.OfflineMermaidScriptFileName,
+                     StringComparison.OrdinalIgnoreCase));
+
+            if (edgeSettingsChanged)
+            {
+                IWebbrowserControl oldEdgeInstance = webview2Instance;
+                oldEdgeInstance.Dispose();
+                webview2Instance = null;
+                webview2OfflineMode = null;
+                webview2OfflineMermaidScriptFileName = null;
+
+                if (ReferenceEquals(webbrowserControl, oldEdgeInstance))
+                    webbrowserControl = null;
+            }
+
             this.settings = newSettings;
 
             var isDarkModeEnabled = newSettings.IsDarkModeEnabled;
@@ -179,9 +216,6 @@ OUTLINE_SCRIPT_PLACEHOLDER
                     tsItem.ForeColor = Color.White;
                 }
 
-                //btnSaveWithLightTheme.ForeColor = Color.White;
-
-                // Footer
                 toolStripStatusLabel1.ForeColor = Color.White;
                 footerStatusStrip.BackColor = Color.Black;
             }
@@ -194,9 +228,6 @@ OUTLINE_SCRIPT_PLACEHOLDER
                     tsItem.ForeColor = SystemColors.ControlText;
                 }
 
-                //btnSaveWithLightTheme.ForeColor = SystemColors.ControlText;
-
-                // Footer
                 footerStatusStrip.BackColor = SystemColors.Control;
                 toolStripStatusLabel1.ForeColor = SystemColors.ControlText;
             }
@@ -204,11 +235,12 @@ OUTLINE_SCRIPT_PLACEHOLDER
             tbPreview.Visible = newSettings.ShowToolbar;
             footerStatusStrip.Visible = newSettings.ShowStatusbar;
 
-            if (webbrowserControl != null && webbrowserControl.GetRenderingEngineName() != settings.RenderingEngine)
+            if (webbrowserControl == null ||
+                webbrowserControl.GetRenderingEngineName() !=
+                    settings.RenderingEngine)
             {
                 InitRenderingEngine(settings, openLocalFileInNppAction);
             }
-
         }
 
         private MarkdownService markdownService;
@@ -256,9 +288,16 @@ OUTLINE_SCRIPT_PLACEHOLDER
             {
                 if (webview2Instance == null)
                 {
-                    webbrowserControl = new Webview2WebbrowserControl();
-                    webbrowserControl.Initialize(newSettings.ZoomLevel, openLocalFileInNppAction);
+                    webbrowserControl = new Webview2WebbrowserControl(
+                        newSettings.OfflineMode,
+                        newSettings.OfflineMermaidScriptFileName);
+                    webbrowserControl.Initialize(
+                        newSettings.ZoomLevel,
+                        openLocalFileInNppAction);
                     webview2Instance = webbrowserControl;
+                    webview2OfflineMode = newSettings.OfflineMode;
+                    webview2OfflineMermaidScriptFileName =
+                        newSettings.OfflineMermaidScriptFileName;
                 }
                 else
                 {
@@ -273,37 +312,140 @@ OUTLINE_SCRIPT_PLACEHOLDER
             webbrowserControl.RadioToggleAction = radioToggleHandler;
         }
 
-        private RenderResult RenderHtmlInternal(string currentText, string filepath)
+        private RenderResult RenderHtmlInternal(
+            string currentText,
+            string filepath)
         {
             var defaultBodyStyle = "";
             var markdownStyleContent = GetCssContent();
-            var htmlTemplate = settings.ShowOutline ? OUTLINE_HTML_BASE : DEFAULT_HTML_BASE;
+            var htmlTemplate =
+                settings.ShowOutline ? OUTLINE_HTML_BASE : DEFAULT_HTML_BASE;
 
             if (!IsValidFileExtension(currentFilePath))
             {
-                var invalidExtensionMessageBody = string.Format(MSG_NO_SUPPORTED_FILE_EXT, Path.GetFileName(filepath), settings.SupportedFileExt);
-                var invalidExtensionMessage = string.Format(htmlTemplate, Path.GetFileName(filepath), markdownStyleContent, defaultBodyStyle, invalidExtensionMessageBody);
-                if (settings.ShowOutline)
-                    invalidExtensionMessage = InjectOutlineScript(invalidExtensionMessage);
+                var invalidExtensionMessageBody = string.Format(
+                    MSG_NO_SUPPORTED_FILE_EXT,
+                    Path.GetFileName(filepath),
+                    settings.SupportedFileExt);
+                var invalidExtensionHtml = string.Format(
+                    htmlTemplate,
+                    Path.GetFileName(filepath),
+                    markdownStyleContent,
+                    defaultBodyStyle,
+                    invalidExtensionMessageBody);
 
-                return new RenderResult(invalidExtensionMessage, invalidExtensionMessage, invalidExtensionMessageBody, markdownStyleContent, invalidExtensionMessage);
+                if (settings.ShowOutline)
+                    invalidExtensionHtml =
+                        InjectOutlineScript(invalidExtensionHtml);
+
+                var invalidExtensionBrowser =
+                    ApplyWebResources(invalidExtensionHtml, true);
+                var invalidExtensionExport =
+                    ApplyWebResources(invalidExtensionHtml, false);
+
+                return new RenderResult(
+                    invalidExtensionBrowser,
+                    invalidExtensionExport,
+                    invalidExtensionMessageBody,
+                    markdownStyleContent,
+                    invalidExtensionExport);
             }
 
-            var resultForBrowser = markdownService.ConvertToHtml(currentText, filepath, true);
-            var resultForExport = markdownService.ConvertToHtml(currentText, null, false);
+            var resultForBrowser =
+                markdownService.ConvertToHtml(currentText, filepath, true);
+            var resultForExport =
+                markdownService.ConvertToHtml(currentText, null, false);
 
-            var markdownHtmlBrowser = string.Format(htmlTemplate, Path.GetFileName(filepath), markdownStyleContent, defaultBodyStyle, resultForBrowser);
-            var markdownHtmlFileExport = string.Format(htmlTemplate, Path.GetFileName(filepath), markdownStyleContent, defaultBodyStyle, resultForExport);
-            var markdownHtmlFileExportWithLightTheme = string.Format(htmlTemplate, Path.GetFileName(filepath), GetCssContent(true), defaultBodyStyle, resultForExport);
+            var markdownHtmlBrowser = string.Format(
+                htmlTemplate,
+                Path.GetFileName(filepath),
+                markdownStyleContent,
+                defaultBodyStyle,
+                resultForBrowser);
+            var markdownHtmlFileExport = string.Format(
+                htmlTemplate,
+                Path.GetFileName(filepath),
+                markdownStyleContent,
+                defaultBodyStyle,
+                resultForExport);
+            var markdownHtmlFileExportWithLightTheme = string.Format(
+                htmlTemplate,
+                Path.GetFileName(filepath),
+                GetCssContent(true),
+                defaultBodyStyle,
+                resultForExport);
 
             if (settings.ShowOutline)
             {
-                markdownHtmlBrowser = InjectOutlineScript(markdownHtmlBrowser);
-                markdownHtmlFileExport = InjectOutlineScript(markdownHtmlFileExport);
-                markdownHtmlFileExportWithLightTheme = InjectOutlineScript(markdownHtmlFileExportWithLightTheme);
+                markdownHtmlBrowser =
+                    InjectOutlineScript(markdownHtmlBrowser);
+                markdownHtmlFileExport =
+                    InjectOutlineScript(markdownHtmlFileExport);
+                markdownHtmlFileExportWithLightTheme =
+                    InjectOutlineScript(
+                        markdownHtmlFileExportWithLightTheme);
             }
 
-            return new RenderResult(markdownHtmlBrowser, markdownHtmlFileExport, resultForBrowser, markdownStyleContent, markdownHtmlFileExportWithLightTheme);
+            markdownHtmlBrowser =
+                ApplyWebResources(markdownHtmlBrowser, true);
+            markdownHtmlFileExport =
+                ApplyWebResources(markdownHtmlFileExport, false);
+            markdownHtmlFileExportWithLightTheme =
+                ApplyWebResources(
+                    markdownHtmlFileExportWithLightTheme,
+                    false);
+
+            return new RenderResult(
+                markdownHtmlBrowser,
+                markdownHtmlFileExport,
+                resultForBrowser,
+                markdownStyleContent,
+                markdownHtmlFileExportWithLightTheme);
+        }
+
+        private string ApplyWebResources(
+            string html,
+            bool forBrowserPreview)
+        {
+            string mermaidScriptTag =
+                GetMermaidScriptTag(forBrowserPreview);
+            string contentSecurityPolicy =
+                settings.OfflineMode
+                    ? OfflineContentSecurityPolicyMetaTag
+                    : String.Empty;
+
+            return html
+                .Replace(
+                    MermaidScriptPlaceholder,
+                    mermaidScriptTag)
+                .Replace(
+                    OfflineContentSecurityPolicyPlaceholder,
+                    contentSecurityPolicy);
+        }
+
+        private string GetMermaidScriptTag(bool forBrowserPreview)
+        {
+            if (!settings.OfflineMode)
+                return MermaidCdnScriptTag;
+
+            string localMermaidScript;
+            if (!WebviewResourceConstants.TryGetExistingLocalFile(
+                settings.OfflineMermaidScriptFileName,
+                out localMermaidScript))
+            {
+                return "<!-- Mermaid disabled: no safe local script " +
+                    "configured for Offline-mode. -->";
+            }
+
+            string scriptUrl = forBrowserPreview
+                ? WebviewResourceConstants.GetOfflineMermaidVirtualUrl(
+                    localMermaidScript)
+                : new Uri(
+                    localMermaidScript,
+                    UriKind.Absolute).AbsoluteUri;
+
+            return "<script src=\"" + scriptUrl +
+                "\" onerror=\"this.remove();\"></script>";
         }
 
         private string GetCssContent(bool forceLightTheme = false)
@@ -497,6 +639,8 @@ OUTLINE_SCRIPT_PLACEHOLDER
             {
                 webview2Instance.Dispose();
                 webview2Instance = null;
+                webview2OfflineMode = null;
+                webview2OfflineMermaidScriptFileName = null;
             }
         }
 

--- a/NppMarkdownPanel/Forms/SettingsForm.cs
+++ b/NppMarkdownPanel/Forms/SettingsForm.cs
@@ -1,5 +1,8 @@
 ﻿using NppMarkdownPanel.Entities;
+using PanelCommon;
 using System;
+using System.Drawing;
+using System.IO;
 using System.Windows.Forms;
 
 namespace NppMarkdownPanel.Forms
@@ -18,6 +21,14 @@ namespace NppMarkdownPanel.Forms
         public bool ShowStatusbar { get; set; }
         public bool EnableThreeStateToggle { get; set; }
         public string RenderingEngine { get; set; }
+        public bool OfflineMode { get; set; }
+        public string OfflineMermaidScriptFileName { get; set; }
+
+        private GroupBox gbOfflineMode;
+        private CheckBox cbOfflineMode;
+        private Label lblOfflineMermaidScript;
+        private TextBox tbOfflineMermaidScript;
+        private Button btnChooseOfflineMermaidScript;
 
 
         public SettingsForm(Settings settings)
@@ -34,8 +45,12 @@ namespace NppMarkdownPanel.Forms
             AllowAllExtensions = settings.AllowAllExtensions;
             SupportFilesWithNoExt = settings.SupportFilesWithNoExt;
             EnableThreeStateToggle = settings.EnableThreeStateToggle;
+            OfflineMode = settings.OfflineMode;
+            OfflineMermaidScriptFileName =
+                settings.OfflineMermaidScriptFileName ?? String.Empty;
 
             InitializeComponent();
+            InitializeOfflineModeControls();
 
             trackBar1.Value = ZoomLevel;
             lblZoomValue.Text = $"{ZoomLevel}%";
@@ -60,6 +75,161 @@ namespace NppMarkdownPanel.Forms
             }
         }
 
+        private void InitializeOfflineModeControls()
+        {
+            const int addedHeight = 110;
+
+            SuspendLayout();
+            ClientSize = new Size(ClientSize.Width, ClientSize.Height + addedHeight);
+
+            gbOfflineMode = new GroupBox();
+            gbOfflineMode.Anchor =
+                AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Bottom;
+            gbOfflineMode.Location = new Point(12, 583);
+            gbOfflineMode.Name = "gbOfflineMode";
+            gbOfflineMode.Size = new Size(672, 98);
+            gbOfflineMode.TabIndex = 29;
+            gbOfflineMode.TabStop = false;
+            gbOfflineMode.Text = "WebView2 Offline-mode";
+
+            cbOfflineMode = new CheckBox();
+            cbOfflineMode.AutoSize = true;
+            cbOfflineMode.Location = new Point(12, 23);
+            cbOfflineMode.Name = "cbOfflineMode";
+            cbOfflineMode.Size = new Size(399, 21);
+            cbOfflineMode.TabIndex = 0;
+            cbOfflineMode.Text =
+                "Block non-local WebView2 requests and background networking";
+            cbOfflineMode.UseVisualStyleBackColor = true;
+            cbOfflineMode.CheckedChanged += cbOfflineMode_CheckedChanged;
+
+            lblOfflineMermaidScript = new Label();
+            lblOfflineMermaidScript.AutoSize = true;
+            lblOfflineMermaidScript.Location = new Point(12, 62);
+            lblOfflineMermaidScript.Name = "lblOfflineMermaidScript";
+            lblOfflineMermaidScript.Size = new Size(151, 17);
+            lblOfflineMermaidScript.TabIndex = 1;
+            lblOfflineMermaidScript.Text = "Local Mermaid JS file:";
+
+            tbOfflineMermaidScript = new TextBox();
+            tbOfflineMermaidScript.Anchor =
+                AnchorStyles.Left | AnchorStyles.Right | AnchorStyles.Top;
+            tbOfflineMermaidScript.Location = new Point(170, 59);
+            tbOfflineMermaidScript.Name = "tbOfflineMermaidScript";
+            tbOfflineMermaidScript.Size = new Size(444, 25);
+            tbOfflineMermaidScript.TabIndex = 2;
+            tbOfflineMermaidScript.TextChanged +=
+                tbOfflineMermaidScript_TextChanged;
+
+            btnChooseOfflineMermaidScript = new Button();
+            btnChooseOfflineMermaidScript.Anchor =
+                AnchorStyles.Right | AnchorStyles.Top;
+            btnChooseOfflineMermaidScript.Location = new Point(620, 57);
+            btnChooseOfflineMermaidScript.Name =
+                "btnChooseOfflineMermaidScript";
+            btnChooseOfflineMermaidScript.Size = new Size(39, 27);
+            btnChooseOfflineMermaidScript.TabIndex = 3;
+            btnChooseOfflineMermaidScript.Text = "...";
+            btnChooseOfflineMermaidScript.UseVisualStyleBackColor = true;
+            btnChooseOfflineMermaidScript.Click +=
+                btnChooseOfflineMermaidScript_Click;
+
+            gbOfflineMode.Controls.Add(cbOfflineMode);
+            gbOfflineMode.Controls.Add(lblOfflineMermaidScript);
+            gbOfflineMode.Controls.Add(tbOfflineMermaidScript);
+            gbOfflineMode.Controls.Add(btnChooseOfflineMermaidScript);
+            Controls.Add(gbOfflineMode);
+
+            cbOfflineMode.Checked = OfflineMode;
+            tbOfflineMermaidScript.Text = OfflineMermaidScriptFileName;
+            UpdateOfflineModeControls();
+
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        private void cbOfflineMode_CheckedChanged(object sender, EventArgs e)
+        {
+            OfflineMode = cbOfflineMode.Checked;
+            UpdateOfflineModeControls();
+        }
+
+        private void tbOfflineMermaidScript_TextChanged(
+            object sender,
+            EventArgs e)
+        {
+            OfflineMermaidScriptFileName = tbOfflineMermaidScript.Text;
+        }
+
+        private void btnChooseOfflineMermaidScript_Click(
+            object sender,
+            EventArgs e)
+        {
+            using (OpenFileDialog openFileDialog = new OpenFileDialog())
+            {
+                openFileDialog.Filter =
+                    "JavaScript files (*.js)|*.js|All files (*.*)|*.*";
+                openFileDialog.RestoreDirectory = true;
+
+                if (openFileDialog.ShowDialog() == DialogResult.OK)
+                {
+                    tbOfflineMermaidScript.Text = openFileDialog.FileName;
+                }
+            }
+        }
+
+        private void UpdateOfflineModeControls()
+        {
+            bool localScriptEnabled = OfflineMode;
+
+            lblOfflineMermaidScript.Enabled = localScriptEnabled;
+            tbOfflineMermaidScript.Enabled = localScriptEnabled;
+            btnChooseOfflineMermaidScript.Enabled = localScriptEnabled;
+        }
+
+        private bool ValidateOfflineModeSettings()
+        {
+            if (!OfflineMode ||
+                String.IsNullOrWhiteSpace(tbOfflineMermaidScript.Text))
+            {
+                OfflineMermaidScriptFileName =
+                    tbOfflineMermaidScript.Text.Trim();
+                return true;
+            }
+
+            string fullPath;
+            if (!WebviewResourceConstants.TryGetExistingLocalFile(
+                tbOfflineMermaidScript.Text,
+                out fullPath))
+            {
+                MessageBox.Show(
+                    "The local Mermaid JavaScript file must be an existing " +
+                    "file on a local drive. UNC paths and mapped network " +
+                    "drives are not allowed in Offline-mode.",
+                    "Invalid Offline-mode Mermaid File",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                return false;
+            }
+
+            if (!String.Equals(
+                Path.GetExtension(fullPath),
+                ".js",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                MessageBox.Show(
+                    "The local Mermaid file must have a .js extension.",
+                    "Invalid Offline-mode Mermaid File",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                return false;
+            }
+
+            OfflineMermaidScriptFileName = fullPath;
+            tbOfflineMermaidScript.Text = fullPath;
+            return true;
+        }
+
         private void trackBar1_ValueChanged(object sender, EventArgs e)
         {
             ZoomLevel = trackBar1.Value;
@@ -77,6 +247,9 @@ namespace NppMarkdownPanel.Forms
 
         private void btnSave_Click(object sender, EventArgs e)
         {
+            if (!ValidateOfflineModeSettings())
+                return;
+
             if (!String.IsNullOrEmpty(tbHtmlFile.Text) && String.IsNullOrEmpty(sblInvalidHtmlPath.Text))
             {
                 bool validHtmlPath = Utils.ValidateFileSelection(tbHtmlFile.Text, out string validPath, out string error, "HTML Output");
@@ -221,6 +394,9 @@ namespace NppMarkdownPanel.Forms
             {
                 throw new NotSupportedException("Rendering Engine with id " + comboRenderingEngine.SelectedIndex + " not supported!");
             }
+
+            if (cbOfflineMode != null)
+                UpdateOfflineModeControls();
         }
 
         private void cbAllowAllExtensions_CheckedChanged(object sender, EventArgs e)

--- a/NppMarkdownPanel/MarkdownPanelController.cs
+++ b/NppMarkdownPanel/MarkdownPanelController.cs
@@ -107,6 +107,8 @@ namespace NppMarkdownPanel
             settings.EnableThreeStateToggle = PluginUtils.ReadIniBool("Options", "EnableThreeStateToggle", iniFilePath);
             settings.RenderingEngine = Win32.ReadIniValue("Options", "RenderingEngine", iniFilePath, Settings.RENDERING_ENGINE_WEBVIEW2_EDGE);
             settings.ShowOutline = PluginUtils.ReadIniBool("Options", "ShowOutline", iniFilePath, false);
+            settings.OfflineMode = PluginUtils.ReadIniBool("Options", "OfflineMode", iniFilePath, false);
+            settings.OfflineMermaidScriptFileName = Win32.ReadIniValue("Options", "OfflineMermaidScriptFileName", iniFilePath, "");
             return settings;
         }
 
@@ -394,6 +396,8 @@ namespace NppMarkdownPanel
                 settings.AutoShowPanel = settingsForm.AutoShowPanel;
                 settings.EnableThreeStateToggle = settingsForm.EnableThreeStateToggle;
                 settings.RenderingEngine = settingsForm.RenderingEngine;
+                settings.OfflineMode = settingsForm.OfflineMode;
+                settings.OfflineMermaidScriptFileName = settingsForm.OfflineMermaidScriptFileName;
 
                 settings.IsDarkModeEnabled = IsDarkModeEnabled();
                 viewerInterface.UpdateSettings(settings, OpenLocalFileInNpp);
@@ -485,6 +489,8 @@ namespace NppMarkdownPanel
             Win32.WriteIniValue("Options", "AllowAllExtensions", settings.AllowAllExtensions.ToString(), iniFilePath);
             Win32.WriteIniValue("Options", "RenderingEngine", settings.RenderingEngine, iniFilePath);
             Win32.WriteIniValue("Options", "ShowOutline", settings.ShowOutline.ToString(), iniFilePath);
+            Win32.WriteIniValue("Options", "OfflineMode", settings.OfflineMode.ToString(), iniFilePath);
+            Win32.WriteIniValue("Options", "OfflineMermaidScriptFileName", settings.OfflineMermaidScriptFileName, iniFilePath);
         }
         private void ShowAboutDialog()
         {

--- a/PanelCommon/PanelCommon.csproj
+++ b/PanelCommon/PanelCommon.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Compile Include="IMarkdownGenerator.cs" />
     <Compile Include="IWebbrowserControl.cs" />
+    <Compile Include="WebviewResourceConstants.cs" />
 		<Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/PanelCommon/WebviewResourceConstants.cs
+++ b/PanelCommon/WebviewResourceConstants.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.IO;
+
+namespace PanelCommon
+{
+    /// <summary>
+    /// Shared virtual-host constants and local-path validation used by the
+    /// Markdown preview and WebView2 host.
+    /// </summary>
+    public static class WebviewResourceConstants
+    {
+        public const string DocumentVirtualHostName = "markdownpanel-virtualhost";
+        public const string DocumentVirtualBaseUrl =
+            "http://" + DocumentVirtualHostName;
+
+        public const string OfflineAssetsVirtualHostName =
+            "markdownpanel-offline.local";
+        public const string OfflineAssetsVirtualBaseUrl =
+            "https://" + OfflineAssetsVirtualHostName + "/";
+
+        public static string GetOfflineMermaidVirtualUrl(string localScriptPath)
+        {
+            string fileName = Path.GetFileName(localScriptPath);
+
+            if (String.IsNullOrWhiteSpace(fileName))
+                fileName = "mermaid.min.js";
+
+            return OfflineAssetsVirtualBaseUrl + Uri.EscapeDataString(fileName);
+        }
+
+        /// <summary>
+        /// Resolves a path to an existing file on a local drive.
+        /// UNC paths, mapped network drives, relative paths, directories,
+        /// invalid paths, and inaccessible files are rejected.
+        /// </summary>
+        public static bool TryGetExistingLocalFile(
+            string path,
+            out string fullPath)
+        {
+            fullPath = null;
+
+            if (String.IsNullOrWhiteSpace(path) || !Path.IsPathRooted(path))
+                return false;
+
+            try
+            {
+                string candidate = Path.GetFullPath(path);
+
+                if (IsNetworkPath(candidate) || !File.Exists(candidate))
+                    return false;
+
+                fullPath = candidate;
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (IOException)
+            {
+                // Includes PathTooLongException.
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Returns true for UNC paths and drive letters mapped to network shares.
+        /// Invalid or inaccessible rooted paths are treated as unsafe.
+        /// </summary>
+        public static bool IsNetworkPath(string path)
+        {
+            if (String.IsNullOrWhiteSpace(path))
+                return false;
+
+            try
+            {
+                if (path.StartsWith(@"\\", StringComparison.Ordinal) ||
+                    path.StartsWith("//", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                if (!Path.IsPathRooted(path))
+                    return false;
+
+                string fullPath = Path.GetFullPath(path);
+                string pathRoot = Path.GetPathRoot(fullPath);
+
+                if (String.IsNullOrWhiteSpace(pathRoot))
+                    return true;
+
+                DriveInfo driveInfo = new DriveInfo(pathRoot);
+                return driveInfo.DriveType == DriveType.Network;
+            }
+            catch (ArgumentException)
+            {
+                return true;
+            }
+            catch (NotSupportedException)
+            {
+                return true;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return true;
+            }
+            catch (IOException)
+            {
+                // Includes PathTooLongException.
+                return true;
+            }
+        }
+    }
+}

--- a/Readme_OfflineMode.md
+++ b/Readme_OfflineMode.md
@@ -1,0 +1,308 @@
+# NppMarkdownPanel WebView2 Offline-mode Changes
+
+## Purpose
+
+This change adds an optional WebView2 Offline-mode to NppMarkdownPanel. The mode is intended for offline, restricted, and firewalled systems where failed network requests caused significant delays while rendering Markdown previews.
+
+The original implementation inserted the following remote Mermaid dependency into rendered preview pages:
+
+```text
+https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
+```
+
+On systems without internet access, attempts to load that file could delay preview rendering. Markdown content could also initiate other browser requests through remote images, stylesheets, scripts, frames, media, links, WebSockets, fetch requests, and similar browser functionality.
+
+No NuGet dependencies were added or changed.
+
+## Modified Files
+
+The implementation changes the following files:
+
+```text
+NppMarkdownPanel\Entities\Settings.cs
+NppMarkdownPanel\Forms\SettingsForm.cs
+NppMarkdownPanel\Forms\MarkdownPreviewForm.cs
+NppMarkdownPanel\MarkdownPanelController.cs
+PanelCommon\PanelCommon.csproj
+Webview2Viewer\Webview2WebbrowserControl.cs
+```
+
+The following shared helper was added:
+
+```text
+PanelCommon\WebviewResourceConstants.cs
+```
+
+## New Settings
+
+Two settings were added:
+
+```text
+OfflineMode
+OfflineMermaidScriptFileName
+```
+
+They are stored in the plugin INI file under the `Options` section:
+
+```ini
+[Options]
+OfflineMode=True
+OfflineMermaidScriptFileName=C:\Approved\WebAssets\mermaid.min.js
+```
+
+The default value of `OfflineMode` is `False`, preserving the original online behavior unless the user explicitly enables the option.
+
+## Settings Interface
+
+A new **WebView2 Offline-mode** section appears at the bottom of the MarkdownPanel settings dialog.
+
+It contains:
+
+1. **Block non-local WebView2 requests and background networking**
+
+   Enables or disables Offline-mode.
+
+2. **Local Mermaid JS file**
+
+   Optionally specifies an approved local copy of `mermaid.min.js`.
+
+The local Mermaid selector is enabled only when Offline-mode is selected.
+
+The selected Mermaid file must:
+
+- Exist.
+- Have a `.js` extension.
+- Be specified using an absolute path.
+- Be stored on a local drive.
+- Not use a UNC path.
+- Not reside on a mapped network drive.
+
+Invalid paths are rejected when the settings are saved.
+
+## Using Offline-mode
+
+1. Open Notepad++.
+2. Select:
+
+   ```text
+   Plugins
+   → MarkdownPanel
+   → Settings
+   ```
+
+3. Under **WebView2 Offline-mode**, enable:
+
+   ```text
+   Block non-local WebView2 requests and background networking
+   ```
+
+4. To use Mermaid diagrams, obtain and approve a local copy of:
+
+   ```text
+   mermaid.min.js
+   ```
+
+   The original plugin used Mermaid version 11 from:
+
+   ```text
+   mermaid@11/dist/mermaid.min.js
+   ```
+
+5. Store the approved JavaScript file on a local drive, for example:
+
+   ```text
+   C:\Approved\WebAssets\mermaid.min.js
+   ```
+
+6. Select that file using the **Local Mermaid JS file** browse button.
+7. Save the settings.
+
+The WebView2 instance is recreated automatically when Offline-mode or the local Mermaid path changes.
+
+## Using Offline-mode Without Mermaid
+
+The local Mermaid file is optional.
+
+When Offline-mode is enabled and no valid local Mermaid file is configured:
+
+- No online Mermaid request is attempted.
+- Mermaid support is disabled.
+- Normal Markdown rendering continues.
+- Mermaid code blocks will not be rendered as diagrams.
+
+There is no network fallback.
+
+## Online-mode Behavior
+
+When Offline-mode is disabled, the original online behavior is retained.
+
+The preview loads Mermaid from:
+
+```text
+https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
+```
+
+The additional Offline-mode request filtering and Content Security Policy are not applied.
+
+## Offline Mermaid Loading
+
+For browser previews, the selected local Mermaid file is exposed to WebView2 through a local virtual host:
+
+```text
+https://markdownpanel-offline.local/
+```
+
+The virtual host maps to the local directory containing the approved Mermaid file.
+
+The mapping uses WebView2's `DenyCors` access mode. This allows the browser to load the file as a script while preventing CORS-enabled access such as `fetch` or `XMLHttpRequest` against the mapped directory.
+
+For saved HTML exports, the generated HTML references the selected Mermaid file using an absolute file URI. The JavaScript is not embedded into the exported HTML.
+
+Consequently, an exported HTML file using Mermaid will continue to depend on the configured local Mermaid file remaining at the same path.
+
+## Content Security Policy
+
+Offline preview pages receive a restrictive Content Security Policy.
+
+The policy:
+
+- Denies resources by default.
+- Allows inline preview styles.
+- Allows inline preview scripts required by the plugin.
+- Allows data URLs for embedded content.
+- Allows local file resources.
+- Allows resources from the local Markdown document virtual host.
+- Allows scripts from the offline Mermaid virtual host.
+- Disables network connections through `connect-src`.
+- Disables frames.
+- Disables embedded objects.
+- Disables forms.
+- Disables alternate base URLs.
+
+This provides a second layer of protection in addition to WebView2 request interception.
+
+## WebView2 Request Filtering
+
+When Offline-mode is enabled, the plugin installs a `WebResourceRequested` filter covering all WebView2 resource contexts.
+
+Requests are allowed only for:
+
+- The local Markdown document virtual host.
+- The local offline-assets virtual host used by Mermaid.
+- Local file URLs that do not reference network paths.
+- `about:` URLs needed internally by WebView2.
+- `data:` URLs.
+- `blob:` URLs.
+
+Other requests are blocked immediately with a local HTTP 403 response:
+
+```text
+Blocked by NppMarkdownPanel Offline-mode.
+```
+
+Blocked categories include:
+
+- External HTTP and HTTPS resources.
+- Remote images.
+- Remote scripts.
+- Remote stylesheets.
+- Remote fonts.
+- Remote media.
+- Remote frames.
+- WebSocket connections.
+- FTP resources.
+- Custom URL protocols.
+- Other unrecognized schemes.
+
+## Navigation and Popup Blocking
+
+When Offline-mode is enabled:
+
+- External page navigation is cancelled.
+- New-window and popup requests are marked as handled and are not opened.
+- Local document links continue to open through Notepad++ where permitted.
+- Links to files on UNC paths or mapped network drives are rejected.
+
+## Local Markdown Resources
+
+The plugin continues to support local resources associated with the current Markdown document, such as local images.
+
+In Offline-mode, the Markdown document directory is mapped only when the document is located on a local drive.
+
+Documents located on UNC paths or mapped network drives are not mapped because accessing them could create network activity.
+
+The local document mapping uses `DenyCors` in Offline-mode.
+
+## Separate WebView2 Profile
+
+Offline-mode uses a separate WebView2 profile directory named:
+
+```text
+webview2-offline
+```
+
+Normal mode continues to use:
+
+```text
+webview2
+```
+
+This prevents the online and offline configurations from sharing the same WebView2 profile state.
+
+## Background Networking Controls
+
+When Offline-mode is enabled, the WebView2 environment is started with browser arguments intended to reduce or disable Chromium background network services.
+
+The configured arguments disable or reduce:
+
+- Background networking.
+- Component updates.
+- Domain reliability reporting.
+- Browser synchronization.
+- Default application activity.
+- Client-side phishing detection.
+- DNS prefetching.
+- Breakpad crash reporting.
+- First-run activity.
+- Optimization hints.
+- Media Router activity.
+- Translation services.
+- Autofill server communication.
+- Certificate Transparency component updates.
+
+Where supported by the installed WebView2 SDK and runtime, the plugin also requests:
+
+- Custom crash reporting instead of the default WebView2 reporting path.
+- Disabling SmartScreen reputation checks.
+
+These optional properties are applied through reflection so the plugin remains compatible with runtimes that do not expose them. The request interceptor and Content Security Policy remain active even if an optional runtime property is unavailable.
+
+## Runtime Scope
+
+Offline-mode controls requests made by the WebView2 instance hosted by NppMarkdownPanel.
+
+It cannot control separate machine-level services outside the plugin process, such as the updater belonging to an installed Evergreen WebView2 Runtime.
+
+Systems requiring a strict machine-wide zero-egress guarantee should continue to enforce an outbound firewall policy or use an appropriately managed WebView2 runtime deployment.
+
+## Settings Changes
+
+Changing either of the following settings causes the existing WebView2 control to be disposed and recreated:
+
+```text
+OfflineMode
+OfflineMermaidScriptFileName
+```
+
+This is required because WebView2 environment options, profile paths, virtual-host mappings, and request filters are established during initialization.
+
+## Expected Result
+
+With Offline-mode enabled:
+
+- The Mermaid CDN is not contacted.
+- Remote Markdown resources are not contacted.
+- External navigation and popup activity are blocked.
+- Disallowed requests fail immediately rather than waiting for network timeouts.
+- Preview rendering remains functional using local content.
+- Mermaid rendering remains available when an approved local Mermaid JavaScript file is configured.

--- a/Webview2Viewer/Webview2WebbrowserControl.cs
+++ b/Webview2Viewer/Webview2WebbrowserControl.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using System.Windows.Forms;
@@ -14,11 +15,29 @@ namespace Webview2Viewer
 {
     public class Webview2WebbrowserControl : IWebbrowserControl, IDisposable
     {
-        const string virtualHostProtocol = "http://";
-        const string virtualHostName = "markdownpanel-virtualhost";
-        const string CONFIG_FOLDER_NAME = "MarkdownPanel";
+        private const string VirtualHostProtocol = "http://";
+        private const string VirtualHostName =
+            WebviewResourceConstants.DocumentVirtualHostName;
+        private const string ConfigFolderName = "MarkdownPanel";
+
+        private const string OfflineBrowserArguments =
+            "--disable-background-networking " +
+            "--disable-component-update " +
+            "--disable-domain-reliability " +
+            "--disable-sync " +
+            "--disable-default-apps " +
+            "--disable-client-side-phishing-detection " +
+            "--disable-dns-prefetch " +
+            "--disable-breakpad " +
+            "--no-first-run " +
+            "--disable-features=OptimizationHints,MediaRouter,Translate," +
+            "AutofillServerCommunication," +
+            "CertificateTransparencyComponentUpdater";
+
         private Microsoft.Web.WebView2.WinForms.WebView2 webView;
         private bool webViewInitialized = false;
+        private readonly bool offlineMode;
+        private readonly string offlineMermaidScriptFileName;
 
         public Action<string> StatusTextChangedAction { get; set; }
         public Action RenderingDoneAction { get; set; }
@@ -37,75 +56,158 @@ namespace Webview2Viewer
         private Action<string> openLocalFileInNppAction;
 
         private CoreWebView2Environment environment = null;
+        private bool documentFolderMappingConfigured;
 
         public Webview2WebbrowserControl()
+            : this(false, null)
         {
+        }
+
+        public Webview2WebbrowserControl(
+            bool offlineMode,
+            string offlineMermaidScriptFileName)
+        {
+            this.offlineMode = offlineMode;
+
+            string localScriptFileName;
+            if (WebviewResourceConstants.TryGetExistingLocalFile(
+                offlineMermaidScriptFileName,
+                out localScriptFileName))
+            {
+                this.offlineMermaidScriptFileName =
+                    localScriptFileName;
+            }
+
             webView = null;
         }
 
         public void Dispose()
         {
-            webView?.Dispose();
-            webView = null;
+            if (webView != null)
+            {
+                webView.Dispose();
+                webView = null;
+            }
+
+            environment = null;
+            webViewInitialized = false;
         }
 
-        public void Initialize(int zoomLevel, Action<string> openLocalFileInNppAction)
+        public async void Initialize(
+            int zoomLevel,
+            Action<string> openLocalFileInNppAction)
         {
             this.openLocalFileInNppAction = openLocalFileInNppAction;
-            var cacheDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), CONFIG_FOLDER_NAME, "webview2");
-            //var props = new Microsoft.Web.WebView2.WinForms.CoreWebView2CreationProperties();
-            //props.UserDataFolder = cacheDir;
-            //props.AdditionalBrowserArguments = "--disable-web-security --allow-file-access-from-files --allow-file-access";
-            webView = new Microsoft.Web.WebView2.WinForms.WebView2();
-            webView.CoreWebView2InitializationCompleted += WebView_CoreWebView2InitializationCompleted;
-            var opt = new CoreWebView2EnvironmentOptions();
 
-            var scheduler = TaskScheduler.FromCurrentSynchronizationContext();
-            CoreWebView2Environment.CreateAsync(null, cacheDir, opt)
-                    .ContinueWith(envTask =>
-                    {
-                        if (envTask.IsFaulted)
-                        {
-                            return;
-                        }
+            string profileFolderName =
+                offlineMode ? "webview2-offline" : "webview2";
+            string cacheDir = Path.Combine(
+                Environment.GetFolderPath(
+                    Environment.SpecialFolder.LocalApplicationData),
+                ConfigFolderName,
+                profileFolderName);
 
-                        environment = envTask.Result;
-                        webView.EnsureCoreWebView2Async(environment)
-                            .ContinueWith(ensureTask =>
-                            {
-                                if (ensureTask.IsFaulted)
-                                {
-                                    return;
-                                }
+            webView =
+                new Microsoft.Web.WebView2.WinForms.WebView2();
 
-                                webView.AccessibleName = "webView";
-                                webView.Name = "webView";
-                                webView.ZoomFactor = ConvertToZoomFactor(zoomLevel);
-                                webView.Source = new Uri("about:blank", UriKind.Absolute);
-                                webView.Location = new Point(1, 27);
-                                webView.Size = new Size(800, 424);
-                                webView.Dock = DockStyle.Fill;
-                                webView.TabIndex = 0;
-                                webView.NavigationStarting += OnWebBrowser_NavigationStarting;
-                                webView.CoreWebView2.WebMessageReceived += WebView_WebMessageReceived;
-                                webView.NavigationCompleted += WebView_NavigationCompleted;
-                                webView.ZoomFactor = ConvertToZoomFactor(zoomLevel);
-                            }, scheduler);
-                    }, scheduler);
+            CoreWebView2EnvironmentOptions options =
+                new CoreWebView2EnvironmentOptions();
+
+            if (offlineMode)
+            {
+                options.AdditionalBrowserArguments =
+                    OfflineBrowserArguments;
+
+                // This property exists in recent WebView2 SDKs. Reflection
+                // keeps the plugin compatible with older SDKs as well.
+                TrySetBooleanProperty(
+                    options,
+                    "IsCustomCrashReportingEnabled",
+                    true);
+            }
+
+            try
+            {
+                environment =
+                    await CoreWebView2Environment.CreateAsync(
+                        null,
+                        cacheDir,
+                        options);
+                await webView.EnsureCoreWebView2Async(environment);
+
+                ConfigureWebView(zoomLevel);
+                webViewInitialized = true;
+
+                Action afterInitialization =
+                    AfterInitCompletedAction;
+                if (afterInitialization != null)
+                    afterInitialization();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(
+                    "WebView2 Initialization Error: " + ex.Message,
+                    "WebView2 Initialization Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
         }
 
-        private void WebView_CoreWebView2InitializationCompleted(object sender, CoreWebView2InitializationCompletedEventArgs e)
+        private void ConfigureWebView(int zoomLevel)
         {
-            if (e.IsSuccess)
+            webView.AccessibleName = "webView";
+            webView.Name = "webView";
+            webView.ZoomFactor = ConvertToZoomFactor(zoomLevel);
+            webView.Location = new Point(1, 27);
+            webView.Size = new Size(800, 424);
+            webView.Dock = DockStyle.Fill;
+            webView.TabIndex = 0;
+
+            webView.NavigationStarting +=
+                OnWebBrowser_NavigationStarting;
+            webView.CoreWebView2.WebMessageReceived +=
+                WebView_WebMessageReceived;
+            webView.NavigationCompleted +=
+                WebView_NavigationCompleted;
+
+            if (offlineMode)
+                ConfigureOfflineMode();
+
+            webView.Source =
+                new Uri("about:blank", UriKind.Absolute);
+        }
+
+        private void ConfigureOfflineMode()
+        {
+            CoreWebView2 coreWebView = webView.CoreWebView2;
+
+            // Disable SmartScreen URL reputation checks when the installed
+            // WebView2 SDK/runtime exposes the setting.
+            TrySetBooleanProperty(
+                coreWebView.Settings,
+                "IsReputationCheckingRequired",
+                false);
+
+            if (!String.IsNullOrWhiteSpace(
+                offlineMermaidScriptFileName))
             {
-                webViewInitialized = true;
-                if (AfterInitCompletedAction != null) AfterInitCompletedAction();
-            }
-            else
-            {
-                MessageBox.Show("WebView2 Initialization Error: " + e?.InitializationException?.Message, "WebView2 Initialization Error");
+                string scriptDirectory = Path.GetDirectoryName(
+                    offlineMermaidScriptFileName);
+
+                coreWebView.SetVirtualHostNameToFolderMapping(
+                    WebviewResourceConstants
+                        .OfflineAssetsVirtualHostName,
+                    scriptDirectory,
+                    CoreWebView2HostResourceAccessKind.DenyCors);
             }
 
+            coreWebView.AddWebResourceRequestedFilter(
+                "*",
+                CoreWebView2WebResourceContext.All);
+            coreWebView.WebResourceRequested +=
+                CoreWebView2_WebResourceRequested;
+            coreWebView.NewWindowRequested +=
+                CoreWebView2_NewWindowRequested;
         }
 
         public void AddToHost(Control host)
@@ -236,11 +338,27 @@ namespace Webview2Viewer
         {
             if (!IsInitialized()) return;
 
-            var currentPath = Path.GetDirectoryName(currentDocumentPath);
-            var replaceFileMapping = "file:///" + currentPath.Replace('\\', '/');
+            string currentPath =
+                Path.GetDirectoryName(currentDocumentPath);
+            bool canMapDocumentFolder =
+                !String.IsNullOrWhiteSpace(currentPath) &&
+                (!offlineMode ||
+                 !WebviewResourceConstants.IsNetworkPath(currentPath));
 
-            content = content.Replace(replaceFileMapping, virtualHostProtocol + virtualHostName);
-            body = body.Replace(replaceFileMapping, virtualHostProtocol + virtualHostName);
+            if (canMapDocumentFolder)
+            {
+                string replaceFileMapping =
+                    "file:///" + currentPath.Replace('\\', '/');
+                string virtualBaseUrl =
+                    VirtualHostProtocol + VirtualHostName;
+
+                content = content.Replace(
+                    replaceFileMapping,
+                    virtualBaseUrl);
+                body = body.Replace(
+                    replaceFileMapping,
+                    virtualBaseUrl);
+            }
 
             var fullReload = false;
             if (forceFullReload)
@@ -252,7 +370,30 @@ namespace Webview2Viewer
             {
                 ExecuteWebviewAction(new Action(() =>
                 {
-                    webView.CoreWebView2.SetVirtualHostNameToFolderMapping(virtualHostName, currentPath, CoreWebView2HostResourceAccessKind.Allow);
+                    if (documentFolderMappingConfigured)
+                    {
+                        webView.CoreWebView2
+                            .ClearVirtualHostNameToFolderMapping(
+                                VirtualHostName);
+                        documentFolderMappingConfigured = false;
+                    }
+
+                    if (canMapDocumentFolder)
+                    {
+                        CoreWebView2HostResourceAccessKind accessKind =
+                            offlineMode
+                                ? CoreWebView2HostResourceAccessKind
+                                    .DenyCors
+                                : CoreWebView2HostResourceAccessKind
+                                    .Allow;
+
+                        webView.CoreWebView2
+                            .SetVirtualHostNameToFolderMapping(
+                                VirtualHostName,
+                                currentPath,
+                                accessKind);
+                        documentFolderMappingConfigured = true;
+                    }
                 }));
                 this.currentDocumentPath = currentDocumentPath;
                 fullReload = true;
@@ -328,30 +469,201 @@ namespace Webview2Viewer
             return zoomFactor;
         }
 
-        void OnWebBrowser_NavigationStarting(object sender, CoreWebView2NavigationStartingEventArgs e)
+        void OnWebBrowser_NavigationStarting(
+            object sender,
+            CoreWebView2NavigationStartingEventArgs e)
         {
-            // Allow same-document fragment navigations (#anchor links)
-            if (e.Uri.ToString().Contains("#"))
-                return;
+            string navUri = e.Uri ?? String.Empty;
+            string documentVirtualBaseUrl =
+                VirtualHostProtocol + VirtualHostName;
 
-            if (e.Uri.ToString().StartsWith("about:blank"))
+            if (navUri.StartsWith(
+                documentVirtualBaseUrl,
+                StringComparison.OrdinalIgnoreCase))
             {
                 e.Cancel = true;
-            }
-            else if (!e.Uri.ToString().StartsWith("data:"))
-            {
-                var navUri = e.Uri.ToString();
-                if (navUri.StartsWith(virtualHostProtocol + virtualHostName))
+
+                string currentPath =
+                    Path.GetDirectoryName(currentDocumentPath);
+                if (String.IsNullOrWhiteSpace(currentPath) ||
+                    (offlineMode &&
+                     WebviewResourceConstants.IsNetworkPath(
+                         currentPath)))
                 {
-                    e.Cancel = true;
-                    var currentPath = Path.GetDirectoryName(currentDocumentPath);
-                    navUri = navUri.Replace(virtualHostProtocol + virtualHostName, currentPath);
-                    navUri = Uri.UnescapeDataString(navUri);
-                    openLocalFileInNppAction(navUri); 
-                } else
-                {
-                    forceFullReload = true;
+                    return;
                 }
+
+                string localPath = navUri.Replace(
+                    documentVirtualBaseUrl,
+                    currentPath);
+                localPath = Uri.UnescapeDataString(localPath);
+
+                if (openLocalFileInNppAction != null)
+                    openLocalFileInNppAction(localPath);
+
+                return;
+            }
+
+            Uri parsedUri;
+            if (!Uri.TryCreate(
+                navUri,
+                UriKind.Absolute,
+                out parsedUri))
+            {
+                if (offlineMode)
+                    e.Cancel = true;
+                return;
+            }
+
+            if (String.Equals(
+                parsedUri.Scheme,
+                "about",
+                StringComparison.OrdinalIgnoreCase))
+            {
+                e.Cancel = true;
+                return;
+            }
+
+            if (offlineMode && !IsAllowedOfflineUri(parsedUri))
+            {
+                e.Cancel = true;
+                forceFullReload = true;
+                return;
+            }
+
+            if (!String.Equals(
+                parsedUri.Scheme,
+                "data",
+                StringComparison.OrdinalIgnoreCase) &&
+                parsedUri.Fragment.Length == 0)
+            {
+                forceFullReload = true;
+            }
+        }
+
+        private void CoreWebView2_WebResourceRequested(
+            object sender,
+            CoreWebView2WebResourceRequestedEventArgs e)
+        {
+            Uri requestUri;
+            if (Uri.TryCreate(
+                e.Request.Uri,
+                UriKind.Absolute,
+                out requestUri) &&
+                IsAllowedOfflineUri(requestUri))
+            {
+                return;
+            }
+
+            byte[] responseBytes = Encoding.UTF8.GetBytes(
+                "Blocked by NppMarkdownPanel Offline-mode.");
+            MemoryStream responseStream =
+                new MemoryStream(responseBytes, false);
+
+            e.Response = environment.CreateWebResourceResponse(
+                responseStream,
+                403,
+                "Blocked by Offline-mode",
+                "Content-Type: text/plain; charset=utf-8\r\n" +
+                "Cache-Control: no-store\r\n");
+        }
+
+        private void CoreWebView2_NewWindowRequested(
+            object sender,
+            CoreWebView2NewWindowRequestedEventArgs e)
+        {
+            e.Handled = true;
+        }
+
+        private bool IsAllowedOfflineUri(Uri uri)
+        {
+            if (uri == null)
+                return false;
+
+            string scheme = uri.Scheme;
+
+            if (String.Equals(
+                scheme,
+                Uri.UriSchemeHttp,
+                StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(
+                    scheme,
+                    Uri.UriSchemeHttps,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                if (String.Equals(
+                    uri.Host,
+                    VirtualHostName,
+                    StringComparison.OrdinalIgnoreCase))
+                {
+                    return documentFolderMappingConfigured;
+                }
+
+                return String.Equals(
+                    uri.Host,
+                    WebviewResourceConstants
+                        .OfflineAssetsVirtualHostName,
+                    StringComparison.OrdinalIgnoreCase) &&
+                    !String.IsNullOrWhiteSpace(
+                        offlineMermaidScriptFileName);
+            }
+
+            if (String.Equals(
+                scheme,
+                Uri.UriSchemeFile,
+                StringComparison.OrdinalIgnoreCase))
+            {
+                return !uri.IsUnc &&
+                    !WebviewResourceConstants.IsNetworkPath(
+                        uri.LocalPath);
+            }
+
+            if (String.Equals(
+                scheme,
+                "about",
+                StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(
+                    scheme,
+                    "data",
+                    StringComparison.OrdinalIgnoreCase) ||
+                String.Equals(
+                    scheme,
+                    "blob",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            // Deny WebSocket, FTP, custom protocols, and every other
+            // unrecognized scheme in Offline-mode.
+            return false;
+        }
+
+        private static void TrySetBooleanProperty(
+            object target,
+            string propertyName,
+            bool value)
+        {
+            if (target == null)
+                return;
+
+            try
+            {
+                var property = target.GetType().GetProperty(
+                    propertyName);
+
+                if (property != null &&
+                    property.CanWrite &&
+                    property.PropertyType == typeof(bool))
+                {
+                    property.SetValue(target, value, null);
+                }
+            }
+            catch (Exception)
+            {
+                // Optional WebView2 properties may not be exposed by an
+                // older installed runtime. Request interception and CSP
+                // remain active regardless.
             }
         }
 


### PR DESCRIPTION
## Summary

This PR adds an optional **Offline-mode** for the WebView2 Markdown preview.
**Made using ChatGPT 5.6, summary mostly written by ChatGPT too.**

The existing preview always references Mermaid from jsDelivr:

```text
https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js
```

On offline or firewalled systems, attempts to access this resource can introduce multi-second delays whenever the preview is opened or refreshed.

When Offline-mode is enabled, the preview avoids external network requests and fails blocked requests immediately rather than waiting for network timeouts.

### Please note:
I am unfamiliar with `mermaid.min.js` & so I have been unable to test it.

My personal experience with `EdgeWebView2` has not been great. Until now I had it blocked by both my firewall and Windows Group Policy, but I needed to enable it for NppMarkdownPanel because IE11 mode no longer works on my Windows 10 setup. The last version using the IE11 option that worked for me was `v0.9.0`; did not try anything else in between.

With EdgeWebView2 firewalled, all previews took several seconds to generate & nothing rendered until the network timeout completed. This made NppMarkdownPanel impractical for my use case & prompted my attempt to add an Offline-mode with ChatGPT's help.

I hope this may also be useful to others who need to restrict `Edge/WebView2` network access while still previewing `.md` files with NppMarkdownPanel.

@mohzy83 , please feel free to use, modify or reject any part of this implementation as you see fit.
Thanks for making NppMarkdownPanel!

## Changes

This PR adds:

* An **Offline-mode** option in the MarkdownPanel settings.
* An optional path to a locally approved `mermaid.min.js` file.
* No online Mermaid fallback while Offline-mode is enabled.
* WebView2 request filtering for non-local resources.
* Blocking of external navigation and popup windows.
* Blocking of UNC paths and mapped network-drive resources.
* A restrictive Content Security Policy for offline previews.
* A separate WebView2 profile for Offline-mode.
* Browser options intended to reduce WebView2 background networking.
* Settings persistence through the existing INI configuration.
* Automatic WebView2 recreation when Offline-mode settings change.

## Offline Mermaid support

Mermaid remains optional in Offline-mode.

Users may select a local copy of `mermaid.min.js`, for example:

```text
C:\Approved\WebAssets\mermaid.min.js
```

The selected file must:

* Exist.
* Use the `.js` extension.
* Be referenced by an absolute path.
* Reside on a local drive.
* Not use a UNC path.
* Not reside on a mapped network drive.

When no valid local Mermaid file is configured, normal Markdown rendering continues, but Mermaid diagrams are not rendered.

There is no network fallback while Offline-mode is enabled.

## Backward compatibility

Offline-mode is disabled by default.

When it is disabled, the existing online behavior is retained, including loading Mermaid from jsDelivr.

No NuGet dependencies were added or changed.

## Motivation

This feature is primarily intended for:

* Offline systems.
* Firewalled corporate environments.
* Restricted networks.
* Systems where external resources must be reviewed and approved before use.

On these systems, avoiding failed network requests significantly improves Markdown preview responsiveness.

## Testing

The solution was compiled successfully using Visual Studio 2022.

The feature was manually tested with Offline-mode enabled, and Markdown preview rendering no longer experiences the previous network-related delays.

Additional implementation and usage details are documented in:

```text
Readme_OfflineMode.md
```

## Scope note

Offline-mode controls requests made by the WebView2 instance hosted by NppMarkdownPanel.

It does not control separate machine-level services, such as the updater associated with an installed Evergreen WebView2 Runtime. Environments requiring strict machine-wide zero-egress enforcement should continue to use an outbound firewall policy or an appropriately managed WebView2 runtime deployment.
