### PR TITLE
Add LaTeX math formula rendering support (#188)

### DIFF
--- a/MarkdigWrapper/MarkdigMarkdownGenerator.cs
+++ b/MarkdigWrapper/MarkdigMarkdownGenerator.cs
@@ -19,6 +19,9 @@ namespace MarkdigWrapper
     {
         private static readonly HtmlSanitizer htmlSanitizer = new HtmlSanitizer();
 
+        private static readonly Regex latexDisplayMathRegex = new Regex(@"(?<!\\)\\\[(?<content>[\s\S]*?)(?<!\\)\\\]");
+        private static readonly Regex latexInlineMathRegex = new Regex(@"(?<!\\)\\\((?<content>[^\r\n]*?)(?<!\\)\\\)");
+
         public MarkdigMarkdownGenerator()
         {
             htmlSanitizer.AllowedAttributes.Add("data-line");
@@ -64,6 +67,7 @@ namespace MarkdigWrapper
 
             try
             {
+                markDownText = ConvertLatexMathDelimiters(markDownText);
                 var document = Markdown.Parse(markDownText, pipeline, null);
 
                 SetLineNoAttributeOnAllBlocks(document);
@@ -85,6 +89,20 @@ namespace MarkdigWrapper
             if (supportEscapeCharsInUris) result = UnescapeAnchorUris(result);
             result = htmlSanitizer.Sanitize(result);
             return result;
+        }
+
+        /// <summary>
+        /// Converts LaTeX math delimiters into the $...$ / $$...$$ form understood by
+        /// Markdig's math extension, so that \(...\) and \[...\] are rendered as math
+        /// instead of being eaten by Markdown backslash escaping.
+        /// </summary>
+        private string ConvertLatexMathDelimiters(string markdown)
+        {
+            // Block math \[ ... \] -> $$ ... $$
+            markdown = latexDisplayMathRegex.Replace(markdown, m => "$$" + m.Groups["content"].Value + "$$");
+            // Inline math \( ... \) -> $ ... $
+            markdown = latexInlineMathRegex.Replace(markdown, m => "$" + m.Groups["content"].Value + "$");
+            return markdown;
         }
 
         private void SetLineNoAttributeOnAllBlocks(ContainerBlock rootBlock)

--- a/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
+++ b/NppMarkdownPanel/Forms/MarkdownPreviewForm.cs
@@ -30,6 +30,10 @@ namespace NppMarkdownPanel.Forms
                     <script>
                     if(typeof mermaid!=='undefined'){{mermaid.initialize({{ startOnLoad: false }});}}
                     </script>
+                    <script>
+                    window.MathJax = {{ tex: {{ inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']] }} }};
+                    </script>
+                    <script src=""https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"" onerror=""this.remove();""></script>
                 </head>
                 <body class=""markdown-body"" style=""{2}"">
                 {3}
@@ -54,6 +58,10 @@ namespace NppMarkdownPanel.Forms
                     <script>
                     if(typeof mermaid!=='undefined'){{mermaid.initialize({{ startOnLoad: false }});}}
                     </script>
+                    <script>
+                    window.MathJax = {{ tex: {{ inlineMath: [['\\(','\\)']], displayMath: [['\\[','\\]']] }} }};
+                    </script>
+                    <script src=""https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"" onerror=""this.remove();""></script>
                 </head>
                 <body class=""outline-enabled"" style=""{2}"">
                     <nav id=""outline-sidebar"" class=""outline-sidebar"">

--- a/NppMarkdownPanel/Resources/nppMdP.tests/Test-Math-LaTeX.md
+++ b/NppMarkdownPanel/Resources/nppMdP.tests/Test-Math-LaTeX.md
@@ -1,0 +1,46 @@
+# LaTeX Math Rendering Test
+
+Math is rendered with MathJax v3 (tex-svg) from a CDN.
+
+## Inline formulas
+
+- Dollar delimiter: $E = mc^2$ inside a sentence.
+- Alternative delimiter: the quadratic formula \(x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}\) also works.
+- Greek letters: $\alpha + \beta = \gamma$ and $\pi \approx 3.14159$.
+
+## Block formulas
+
+Sum of integers with `$$...$$`:
+
+$$\sum_{i=1}^{n} x_i = \frac{n(n+1)}{2}$$
+
+Matrix with `\[...\]`:
+
+\[
+A_{m,n} =
+\begin{pmatrix}
+  a_{1,1} & a_{1,2} & \cdots & a_{1,n} \\
+  a_{2,1} & a_{2,2} & \cdots & a_{2,n} \\
+  \vdots  & \vdots  & \ddots & \vdots  \\
+  a_{m,1} & a_{m,2} & \cdots & a_{m,n}
+\end{pmatrix}
+\]
+
+Integral with an `equation` environment:
+
+$$
+\begin{equation}
+  \int_0^\infty \frac{x^3}{e^x-1}\,dx = \frac{\pi^4}{15}
+  \label{eq:sample}
+\end{equation}
+$$
+
+## Mixed content
+
+The energy-mass equivalence is $E = mc^2$, while the area of a circle is:
+
+$$
+A = \pi r^2
+$$
+
+An inline reference \(e^{i\pi} + 1 = 0\) (Euler's identity).


### PR DESCRIPTION
Load MathJax v3 from CDN in the preview templates and convert \(...\)/\[...\] delimiters to $...$/1779...1779 so Markdig's math extension renders them instead of Markdown backslash-escaping stripping the delimiters.
Closes #188